### PR TITLE
Adds dbus-python to the dependencies list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Make sure the file for your language is in the [po](/po) folder. If it is just s
 
 #### Installing dependencies
 ```bash
-pip install PyQt6 PyQt6-WebEngine
+pip install PyQt6 PyQt6-WebEngine dbus-python
 ```
 #### Running the application
 ```bash


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/edson/Documents/zapzap/zapzap/__main__.py", line 4, in <module>
    from zapzap.controllers.main_window import MainWindow
  File "/home/edson/Documents/zapzap/zapzap/controllers/main_window.py", line 8, in <module>
    from zapzap.controllers.home import Home
  File "/home/edson/Documents/zapzap/zapzap/controllers/home.py", line 4, in <module>
    from zapzap.controllers.user_container import UserContainer
  File "/home/edson/Documents/zapzap/zapzap/controllers/user_container.py", line 5, in <module>
    from zapzap.engine.browser import Browser
  File "/home/edson/Documents/zapzap/zapzap/engine/browser.py", line 11, in <module>
    import zapzap.services.dbus_notify as dbus
  File "/home/edson/Documents/zapzap/zapzap/services/dbus_notify.py", line 16, in <module>
    import dbus
ModuleNotFoundError: No module named 'dbus'
```