### PR TITLE
Patch unhandled dbus exception

### DIFF
--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -103,7 +103,10 @@ def main():
         window.hide()
         if window.settings.value(
                 "system/background_message", True, bool):
-            excBackgroundNotification()
+            try:
+                excBackgroundNotification()
+            except RuntimeError as e:
+                print(f"{e}")
     else:
         window.show()
 


### PR DESCRIPTION
# Patch Contents

Fixes #240 

Handle `DBusException` returned by `bus.get_object(name, path)` and set a flag.

Still output to terminal to provide user accurate information but allow program to start and function even without a notification message handling system on dbus. The output will look similar to the following: `You are trying to call 'notify.show()' but no notifier could be found on your system` when `.show()` is called on a notification object similar to the `UninitializedError` exception.

