### PR TITLE
Suporte a sessões Wayland puras

### DIFF
--- a/_packaging/flatpak/com.rtosta.zapzap.yaml
+++ b/_packaging/flatpak/com.rtosta.zapzap.yaml
@@ -1,9 +1,9 @@
 app-id: com.rtosta.zapzap
 runtime: org.kde.Platform
-runtime-version: "6.7"
+runtime-version: "6.8"
 sdk: org.kde.Sdk
 base: com.riverbankcomputing.PyQt.BaseApp
-base-version: "6.7"
+base-version: "6.8"
 command: zapzap
 finish-args:
   - "--share=ipc"

--- a/_packaging/flatpak/com.rtosta.zapzap.yaml
+++ b/_packaging/flatpak/com.rtosta.zapzap.yaml
@@ -8,6 +8,7 @@ command: zapzap
 finish-args:
   - "--share=ipc"
   - "--socket=fallback-x11"
+  - "--socket=wayland"
   - "--socket=pulseaudio"
   - "--share=network"
   - "--device=all"
@@ -17,7 +18,7 @@ finish-args:
   - "--talk-name=org.kde.StatusNotifierWatcher"
   - "--env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess"
   - "--env=QT_SCALE_FACTOR_ROUNDING_POLICY=RoundPreferFloor"
-  - "--env=DRI_PRIME=0"
+  - "--env=DRI_PRIME=1"
 
 cleanup:
   - /include

--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -25,31 +25,7 @@ def excBackgroundNotification():
     n.setHint('desktop-entry', 'com.rtosta.zapzap')
     n.show()
 
-
-def runLocal():
-    qset = QSettings(zapzap.__appname__, zapzap.__appname__)
-
-    ZAP_SESSION_TYPE = 'wayland'
-    if not qset.value("system/wayland", True, bool):  # if False, X11
-        ZAP_SESSION_TYPE = 'xcb'
-
-    # Session Type
-    XDG_SESSION_TYPE = getenv('XDG_SESSION_TYPE')
-    if XDG_SESSION_TYPE == 'wayland':
-        environ['QT_QPA_PLATFORM'] = ZAP_SESSION_TYPE
-    elif XDG_SESSION_TYPE is None:
-        environ['QT_QPA_PLATFORM'] = ZAP_SESSION_TYPE
-
-    # Incorrect sizing and bad text rendering with WebEngine using fractional scaling on Wayland
-    environ['QT_SCALE_FACTOR_ROUNDING_POLICY'] = 'RoundPreferFloor'
-
-
 def main():
-
-    # When running outside Flatpak
-    if not zapzap.isFlatpak:
-        runLocal()
-
     # Local Debug (python -m zapzap --zapDebug)
     if '--zapDebug' in sys.argv:
         # Settings for Debug
@@ -59,6 +35,15 @@ def main():
         os.environ['QT_QPA_PLATFORM'] = 'xcb'
         os.environ['QTWEBENGINE_REMOTE_DEBUGGING'] = '12345'
         os.environ["QTWEBENGINE_DICTIONARIES_PATH"] = '/home/tosta/Documentos/GitHub/qtwebengine_dictionaries/'
+
+    # If Linux, use Wayland if available, even on NVidia this will
+    # produce a better result than XWayland
+    if sys.platform == "linux" or sys.platform == "linux2":
+        XDG_SESSION_TYPE = getenv('XDG_SESSION_TYPE')
+        if XDG_SESSION_TYPE == 'wayland':
+            os.environ['QT_QPA_PLATFORM'] = 'wayland'
+        else:
+            os.environ['QT_QPA_PLATFORM'] = 'xcb'
 
     # Create Database
     createDB()

--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -1,4 +1,5 @@
 import sys
+import os
 import zapzap
 from zapzap.controllers.SingleApplication import SingleApplication
 from zapzap.controllers.main_window import MainWindow
@@ -28,8 +29,6 @@ def excBackgroundNotification():
 def main():
     # Local Debug (python -m zapzap --zapDebug)
     if '--zapDebug' in sys.argv:
-        # Settings for Debug
-        import os
         os.environ['XCURSOR_SIZE'] = '24'
         os.environ['XCURSOR_THEME'] = 'Fluent-cursor'
         os.environ['QT_QPA_PLATFORM'] = 'xcb'


### PR DESCRIPTION
- Adiciona o soquete wayland
- Redefine QPA baseado em `XDG_SESSION_TYPE`
- Usa 1 para DRI_PRIME resolvendo problemas de lentidão, tearing e glitches em placas híbridas Intel-AMD

 