### PR TITLE
Fix the clipboard when the image is copied from a browser

### DIFF
--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -78,6 +78,8 @@ def main():
         clip_handle = ClipboardHandler()
     except:
         print("Erro: ClipboardHandler") """
+    clipboard = QGuiApplication.clipboard()
+    clipboard.dataChanged.connect(fix_clipboard_image)
 
     # Create main window
     main_window = MainWindow()


### PR DESCRIPTION
Fix bug that prevented pasting an image into a chat if that image was copied from a browser