### PR TITLE
Add accept-language to webview profile

### DIFF
--- a/zapzap/__init__.py
+++ b/zapzap/__init__.py
@@ -22,6 +22,7 @@ __donationPage__ = 'https://rtosta.com/zapzap/#donate'
 __whatsapp_url__ = 'https://web.whatsapp.com/'
 # Link para pegar o userAgent: http://httpbin.org/user-agent
 __user_agent__ = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36"
+__accept_language_suffix__ = ";q=0.9,en-US;q=0.8,en;q=0.7"
 
 LIMITE_USERS = 3
 

--- a/zapzap/controllers/WebView.py
+++ b/zapzap/controllers/WebView.py
@@ -8,7 +8,7 @@ from PyQt6.QtGui import QAction, QImage
 
 from zapzap.controllers.PageController import PageController
 from zapzap.models import User
-from zapzap import __user_agent__, __whatsapp_url__
+from zapzap import __user_agent__, __accept_language_suffix__, __whatsapp_url__
 from zapzap.services.DictionariesManager import DictionariesManager
 from zapzap.services.DownloadManager import DownloadManager
 from zapzap.services.NotificationManager import NotificationManager
@@ -71,6 +71,7 @@ class WebView(QWebEngineView):
         self.profile.settings().setAttribute(
             QWebEngineSettings.WebAttribute.ScrollAnimatorEnabled, SettingsManager.get("web/scroll_animator", False))
 
+        self.configure_accept_languages()
         self.configure_spellcheck()
 
         size_cache = SettingsManager.get("performance/cache_size_max", 0)
@@ -80,6 +81,12 @@ class WebView(QWebEngineView):
                 "performance/cache_type", "DiskHttpCache")))
 
         self.print_qwebengineprofile_info(self.profile)
+
+    def configure_accept_languages(self):
+        """Configure o idioma para o cabeçalho Accept-Language."""
+        system_language = DictionariesManager.get_system_language()
+        accept_language_string = f"{system_language.replace('_', '-')},{system_language.split('_')[0]}{__accept_language_suffix__}"
+        self.profile.setHttpAcceptLanguage(accept_language_string)
 
     def configure_spellcheck(self):
         """Configura o corretor ortográfico."""
@@ -291,4 +298,5 @@ class WebView(QWebEngineView):
         logger.info(f"Spell Check Habilitado: {profile.isSpellCheckEnabled()}")
         logger.info(f"""Linguagens do Spell Check: {
                     profile.spellCheckLanguages()}""")
+        logger.info(f"Accept-Language Header: {profile.httpAcceptLanguage()}")
         logger.info("=========================================")


### PR DESCRIPTION
Presumably due to missing language files, WebView always defaults to English. These changes manually set the Accept-Language header based on the system language. Thus, WhatsApp Web will also be displayed in the corresponding language.