### PR TITLE
Add uv tool installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ pip install .
 pip uninstall zapzap
 ```
 
+#### uv tool
+Provides a global `zapzap` command in isolated environment.
+```bash
+uv tool install . --with-requirements requirements.txt
+```
+
 ## 📦 Packaging
 - **[Fedora Copr](/fedora_copr.spec)** 
 - **[Flatpak](https://github.com/flathub/com.rtosta.zapzap)**


### PR DESCRIPTION
This PR just adds an additional option in the README.md to use `uv tool` to install the zapzap-application. I'm on Arch, and there is a package for zapzap on AUR, but it don't seem to take any requirements into account. This was a work around that I did and it should also work for any other OS.