### PR TITLE
Fixing Chromium Flags being ignored and Wayland support

### DIFF
--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -21,6 +21,8 @@ def main():
         description="Gerenciar configurações do zapzap")
     parser.add_argument("--setSettings", nargs=2, metavar=("chave",
                         "valor"), help="Define uma configuração específica")
+    parser.add_argument("--wayland", action="store_true",
+                        help="Força o uso do Wayland (QT_QPA_PLATFORM=wayland)")
     args, unknown = parser.parse_known_args()
 
     if args.setSettings:
@@ -30,9 +32,6 @@ def main():
             SettingsManager.set(chave, valor)
         except ValueError:
             print(f"Erro: O valor '{valor}' não é um número inteiro válido.")
-
-    else:
-        print("Argumento inválido ou ausente")
 
     SetupManager.apply()
     TranslationManager.apply()

--- a/zapzap/config/SetupManager.py
+++ b/zapzap/config/SetupManager.py
@@ -24,9 +24,15 @@ class SetupManager:
         # Configuração da plataforma gráfica
         if not SetupManager._is_flatpak:
             # Define a plataforma antes do Qt iniciar
-            environ["QT_QPA_PLATFORM"] = SetupManager.get_qt_platform()
-            logger.info(
-                f"""Plataforma gráfica configurada: {environ['QT_QPA_PLATFORM']}""")
+            platform = SetupManager.get_qt_platform()
+            if platform:
+                environ["QT_QPA_PLATFORM"] = platform
+                logger.info(
+                    f"""Plataforma gráfica configurada: {environ['QT_QPA_PLATFORM']}""")
+            else:
+                 logger.info(
+                    f"""Plataforma gráfica mantida : {environ.get('QT_QPA_PLATFORM')}""")
+
         else:
             logger.info(
                 """Ambiente Flatpak detectado, plataforma gráfica não alterada.""")
@@ -45,7 +51,34 @@ class SetupManager:
             dictionary_path}""")
 
         # Permite a reprodução de áudios e arquivos mp4 ()
-        environ["QTWEBENGINE_CHROMIUM_FLAGS"] = "--disable-features=FFmpegAllowLists"
+        # Recupera flags existentes (do sistema ou definidos pelo usuário via --setSettings)
+        existing_flags = environ.get("QTWEBENGINE_CHROMIUM_FLAGS", "")
+        settings_flags = SettingsManager.get("QTWEBENGINE_CHROMIUM_FLAGS", "")
+        
+        # Combina flags, priorizando ambiente > settings > hardcoded
+        # Nota: Se o usuário define flags via env var, assumimos que ele sabe o que faz.
+        # Se define via settings, concatenamos.
+        
+        # Vamos garantir que --disable-features=FFmpegAllowLists esteja presente
+        required_flag = "--disable-features=FFmpegAllowLists"
+        
+        flags_list = []
+        if existing_flags:
+            flags_list.extend(existing_flags.split())
+        if settings_flags:
+            # Avoid duplicating flags if possible, though Chromium handles duplicates usually.
+            # Convert to list to simple Append
+            flags_list.extend(settings_flags.split())
+             
+        # Filter out potential conflicting flags
+        # Remove --ozone-platform flags as they conflict with QT_QPA_PLATFORM
+        final_flags = [f for f in flags_list if not f.startswith("--ozone-platform")]
+
+        if required_flag not in final_flags:
+             final_flags.append(required_flag)
+
+        environ["QTWEBENGINE_CHROMIUM_FLAGS"] = " ".join(final_flags)
+        logger.info(f"QTWEBENGINE_CHROMIUM_FLAGS final: {environ['QTWEBENGINE_CHROMIUM_FLAGS']}")
 
         # Informação sobre o ambiente de execução
         SetupManager.printEnviron()
@@ -95,6 +128,15 @@ class SetupManager:
 
     @staticmethod
     def get_qt_platform():
+        # Se QT_QPA_PLATFORM já estiver definido no ambiente, respeita ele.
+        if "QT_QPA_PLATFORM" in environ:
+            return None
+
+        # Verifica flag explicito --wayland
+        import sys
+        if "--wayland" in sys.argv:
+            return "wayland"
+
         # Session Type
         XDG_SESSION_TYPE = getenv('XDG_SESSION_TYPE')
         print('XDG_SESSION_TYPE:', XDG_SESSION_TYPE)


### PR DESCRIPTION
- Respects Environment Flags: The application now preserves existing QTWEBENGINE_CHROMIUM_FLAGS from the system environment and user settings, appending required internal flags (like FFmpegAllowLists) rather than overwriting them completely.

- Conflict Prevention: Automatically filters out --ozone-platform arguments from Chromium flags to prevent conflicts with Qt's platform abstraction (QT_QPA_PLATFORM)

- Enhanced Wayland Control:
  - Added a new CLI argument --wayland to explicitly force the Wayland platform.
  - Updated logic to prioritize the QT_QPA_PLATFORM environment variable if it's already set, ensuring user environment configurations are not overridden by auto-detection.