### PR TITLE
Fixes clipboard paste freezes

### DIFF
--- a/zapzap/controllers/MainWindow.py
+++ b/zapzap/controllers/MainWindow.py
@@ -1,5 +1,5 @@
 from PyQt6.QtWidgets import QMainWindow, QApplication
-from PyQt6.QtCore import QByteArray, Qt, QEvent, QBuffer, QTimer, QIODevice
+from PyQt6.QtCore import QByteArray, Qt, QBuffer, QTimer, QIODevice
 from zapzap.controllers.QtoasterDonation import QtoasterDonation
 from zapzap.controllers.Settings import Settings
 from zapzap.controllers.Browser import Browser
@@ -9,7 +9,7 @@ from zapzap.services.SettingsManager import SettingsManager
 from zapzap.services.SysTrayManager import SysTrayManager
 from zapzap.services.ThemeManager import ThemeManager
 from zapzap.views.ui_mainwindow import Ui_MainWindow
-from PyQt6.QtGui import QImage
+from PyQt6.QtGui import QAction, QImage
 
 
 class MainWindow(QMainWindow, Ui_MainWindow):
@@ -30,14 +30,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
 
         if not SettingsManager.get("notification/donation_message", False):
             QtoasterDonation.showMessage(parent=self)
-
-    def changeEvent(self, event):
-        super().changeEvent(event)
-        # For #509: Use delayed clipboard access to avoid race condition with wayland comp
-        if event.type() == QEvent.Type.ActivationChange and self.isActiveWindow():
-            clipboard = QApplication.clipboard()
-            if not clipboard.image().isNull():
-                QTimer.singleShot(50, self._on_paste)
 
     def _on_paste(self):
         clipboard = QApplication.clipboard()
@@ -71,6 +63,16 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.stackedWidget.addWidget(self.browser)
         self._connect_menu_actions()
         self.settings_menubar()
+
+        self.paste_shortcut_ctrl_v = QAction("", self)
+        self.paste_shortcut_ctrl_v.setShortcut("Ctrl+V")
+        self.paste_shortcut_ctrl_v.triggered.connect(self._on_paste)
+        self.addAction(self.paste_shortcut_ctrl_v)
+
+        self.paste_shortcut_shift_insert = QAction("", self)
+        self.paste_shortcut_shift_insert.setShortcut("Shift+Insert")
+        self.paste_shortcut_shift_insert.triggered.connect(self._on_paste)
+        self.addAction(self.paste_shortcut_shift_insert)
 
     def load_settings(self):
         """Restaura as configurações salvas da janela e do sistema."""


### PR DESCRIPTION
Recently I was getting really annoyed when pasting images on my chats, it was super llaggy and it frozen for a tiny bit, enough to make the UX horrible.

Digging up I saw a fix for #509 and then I saw an introduced 50ms forzed delay.

`zapzap/controllers/MainWindow.py:34-65`
```python
def changeEvent(self, event):
    if event.type() == QEvent.Type.ActivationChange and self.isActiveWindow():
        clipboard = QApplication.clipboard()
        if not clipboard.image().isNull():
            QTimer.singleShot(50, self._on_paste)  # 50ms delay
def _on_paste(self):
    # Converts clipboard image to standardized PNG format
    image = clipboard.image()
    buffer = QBuffer()
    image.save(buffer, "PNG")          # <-- Heavy sync operation
    clean_img.loadFromData(buffer)     # <-- Another heavy operation
    clipboard.setImage(clean_img)      # <-- Writes back to clipboard
```

This code was running on `ActivationChange` so even on window focus this would trigger. 
The encoding/decoding is sync so it adds another layer of delay.
And we are transforming into PNG the clipboard when Whatsapp Web already does all of this behind the scenes, so ZapZap shouldn't do this.

So I removed `changeEvent` and created some clipboard keyboard shortcuts... now ZapZap is extremely fast when pasting images/text!

I've tested on X11 and Wayland (using Weston) and I do not see any freezes/crashes/segfaults whatsoever related to the clipboard pasting, but it would be awesome if someone could test a bit more because I do not want to introduce a regression.