### PR TITLE
notifications: make Freedesktop backend resilient to transient DBus service loss

### DIFF
--- a/zapzap/notifications/FreedesktopNotificationBackend.py
+++ b/zapzap/notifications/FreedesktopNotificationBackend.py
@@ -121,6 +121,9 @@ class DBusConnection:
         if dbus is None:
             return
 
+        self.interface = None
+        self.available = False
+
         try:
             if DBusGMainLoop:
                 DBusGMainLoop(set_as_default=True)
@@ -140,23 +143,36 @@ class DBusConnection:
         except Exception:
             self.available = False
 
+    def _mark_unavailable(self):
+        self.available = False
+        self.interface = None
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
     def notify(self, notification: "DBusNotification") -> bool:
-        if not self.available:
+        if not self.available or self.interface is None:
+            # Notification daemons can restart mid-session.
+            # Retry connection lazily without crashing the app.
+            self._init()
+
+        if not self.available or self.interface is None:
             return False
 
-        nid = self.interface.Notify(
-            self.app_name,
-            notification.id,
-            notification.icon,   # fallback
-            notification.title,
-            notification.body,
-            notification.actions_list(),
-            notification.hints,  # image-path aqui
-            notification.timeout,
-        )
+        try:
+            nid = self.interface.Notify(
+                self.app_name,
+                notification.id,
+                notification.icon,   # fallback
+                notification.title,
+                notification.body,
+                notification.actions_list(),
+                notification.hints,  # image-path aqui
+                notification.timeout,
+            )
+        except Exception:
+            self._mark_unavailable()
+            return False
 
         for old in list(self._notifications.values()):
             if notification.matches(old):
@@ -171,7 +187,7 @@ class DBusConnection:
             try:
                 self.interface.CloseNotification(notification.id)
             except Exception:
-                pass
+                self._mark_unavailable()
 
     # ------------------------------------------------------------------
     # DBus callbacks

--- a/zapzap/notifications/NotificationService.py
+++ b/zapzap/notifications/NotificationService.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from gettext import gettext as _
+import logging
 
 from PyQt6.QtWebEngineCore import QWebEngineNotification
 
@@ -13,6 +14,8 @@ from zapzap.notifications.PortalNotificationBackend import (
 from zapzap.notifications.FreedesktopNotificationBackend import (
     FreedesktopNotificationBackend
 )
+
+logger = logging.getLogger(__name__)
 
 
 def is_flatpak() -> bool:
@@ -85,9 +88,16 @@ class NotificationService:
         # =================================================
         # 3. Delegação total ao backend
         # =================================================
-        self.backend.notify(
-            page=page,
-            notification=notification,
-            title=title,
-            message=message,
-        )
+        try:
+            self.backend.notify(
+                page=page,
+                notification=notification,
+                title=title,
+                message=message,
+            )
+        except Exception:
+            # Notification failures must never crash the app.
+            logger.warning(
+                "Notification backend failed; dropping notification",
+                exc_info=True,
+            )


### PR DESCRIPTION
## Summary
This PR prevents ZapZap from crashing when `org.freedesktop.Notifications` is temporarily unavailable (for example when the notification daemon restarts or is briefly absent during session startup).

## Problem
`FreedesktopNotificationBackend` currently assumes DBus notification service availability once initialized.
If the service disappears later, `self.interface.Notify(...)` raises and the exception bubbles up to UI code, terminating the app.

Typical error seen in crash dumps:
`dbus.exceptions.DBusException: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable`

## Changes
- `zapzap/notifications/FreedesktopNotificationBackend.py`
  - reset connection state before (re)initialization;
  - add `_mark_unavailable()` helper;
  - in `notify()`, attempt lazy reconnection when backend is unavailable;
  - catch runtime DBus failures in `Notify(...)`, mark backend unavailable, and return safely;
  - in `close_notification()`, mark backend unavailable if DBus call fails.

- `zapzap/notifications/NotificationService.py`
  - wrap backend `notify(...)` call in `try/except`;
  - log warning instead of allowing notification errors to crash the app.

## Why this approach
- Keeps notification path best-effort.
- Preserves current behavior when daemon is healthy.
- Handles service restarts without requiring app restart.
- Ensures notification failures do not take down the entire application.

## Validation
- `python -m py_compile zapzap/notifications/FreedesktopNotificationBackend.py zapzap/notifications/NotificationService.py`
- Local reproduction context: Arch Linux + Wayland (`niri`) with intermittent `org.freedesktop.Notifications` availability.

## Related
- #583