### PR TITLE
Add WhatsApp profile photos to sidebar page buttons

### DIFF
--- a/zapzap/controllers/Browser.py
+++ b/zapzap/controllers/Browser.py
@@ -164,6 +164,9 @@ class Browser(QWidget, Ui_Browser):
         new_page.update_button_signal.connect(
             self.update_page_button_number_notifications
         )
+        new_page.update_button_photo_signal.connect(
+            self.update_page_button_photo
+        )
         self.pages.addWidget(new_page)
 
         # Criar o botão correspondente
@@ -446,6 +449,11 @@ class Browser(QWidget, Ui_Browser):
             self.page_buttons[page_index].update_notifications(
                 number_notifications)
             self._update_total_notifications()
+
+    def update_page_button_photo(self, page_index, photo_data_url):
+        """Atualiza a foto exibida em um botão específico da barra lateral."""
+        if page_index in self.page_buttons:
+            self.page_buttons[page_index].update_user_photo(photo_data_url)
 
     def _update_total_notifications(self):
         """Atualiza o total de notificações no SysTrayManager."""

--- a/zapzap/controllers/PageButton.py
+++ b/zapzap/controllers/PageButton.py
@@ -45,6 +45,7 @@ class PageButton(QPushButton):
         super().__init__(parent)
         self._user = user
         self.page_index = page_index
+        self.photo_data_url = None
 
         self._setup_ui()
         self.update_user_icon()
@@ -65,6 +66,11 @@ class PageButton(QPushButton):
         self.setMaximumSize(QSize(40, 40))
         self.setStyleSheet(self.STYLE_NORMAL)
 
+    def update_user_photo(self, photo_data_url):
+        """Atualiza a foto exibida no botão da página."""
+        self.photo_data_url = photo_data_url or None
+        self.update_user_icon()
+
     def update_user_icon(self):
         """Atualiza o ícone do usuário e a dica de ferramenta."""
         # Define o tipo de ícone com base no status do usuário
@@ -75,8 +81,14 @@ class PageButton(QPushButton):
             user_icon_type = UserIcon.Type.Silence
 
         # Atualiza o ícone e a dica de ferramenta
-        self.setIcon(UserIcon.get_icon(self._user.icon,
-                     user_icon_type, self.number_notifications))
+        self.setIcon(
+            UserIcon.get_account_icon(
+                self._user.icon,
+                self.photo_data_url,
+                user_icon_type,
+                self.number_notifications,
+            )
+        )
         tooltip = (
             f"{self._user.name} ({self.number_notifications})"
             if self.number_notifications > 0

--- a/zapzap/resources/UserIcon.py
+++ b/zapzap/resources/UserIcon.py
@@ -1,5 +1,15 @@
-from PyQt6.QtGui import QImage, QPixmap, QIcon
-from PyQt6.QtCore import QSize
+from PyQt6.QtGui import (
+    QImage,
+    QPixmap,
+    QIcon,
+    QColor,
+    QPainter,
+    QPainterPath,
+    QPen,
+    QFont,
+)
+from PyQt6.QtCore import QSize, Qt
+import base64
 import random
 from enum import Enum
 
@@ -70,6 +80,14 @@ class UserIcon:
         return f'rgb({random.randint(0, 255)}, {random.randint(0, 255)}, {random.randint(0, 255)})'
 
     @staticmethod
+    def get_account_icon(svg_str: str = ICON_DEFAULT, photo_source: str | None = None, icon_type=Type.Default, qtd: int = 0) -> QIcon:
+        """Gera um ícone com foto do perfil quando disponível, mantendo badges."""
+        photo_pixmap = UserIcon._load_photo_pixmap(photo_source)
+        if photo_pixmap and not photo_pixmap.isNull():
+            return UserIcon._build_photo_icon(photo_pixmap, icon_type, qtd)
+        return UserIcon.get_icon(svg_str, icon_type, qtd)
+
+    @staticmethod
     def get_icon(svg_str: str = ICON_DEFAULT, icon_type=Type.Default, qtd: int = 0) -> QIcon:
         """Gera um QIcon a partir de um SVG."""
         if icon_type == UserIcon.Type.Default:
@@ -91,6 +109,96 @@ class UserIcon:
         qimg = QImage.fromData(svg_bytes, 'SVG')
         qpix = QPixmap.fromImage(qimg)
         return QIcon(qpix.scaled(QSize(128, 128)))
+
+    @staticmethod
+    def _load_photo_pixmap(photo_source: str | None) -> QPixmap | None:
+        """Converte uma data URL PNG/JPEG em QPixmap."""
+        if not photo_source:
+            return None
+
+        try:
+            if photo_source.startswith('data:image'):
+                _, encoded = photo_source.split(',', 1)
+                raw = base64.b64decode(encoded)
+                pixmap = QPixmap()
+                if pixmap.loadFromData(raw):
+                    return pixmap
+        except Exception:
+            return None
+        return None
+
+    @staticmethod
+    def _build_photo_icon(photo_pixmap: QPixmap, icon_type, qtd: int) -> QIcon:
+        """Desenha a foto em formato circular com badges de status e notificações."""
+        size = 128
+        pixmap = QPixmap(size, size)
+        pixmap.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(pixmap)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setRenderHint(QPainter.RenderHint.SmoothPixmapTransform)
+
+        avatar_rect = pixmap.rect().adjusted(6, 6, -6, -6)
+        path = QPainterPath()
+        path.addEllipse(avatar_rect)
+        painter.setClipPath(path)
+        scaled = photo_pixmap.scaled(
+            avatar_rect.size(),
+            Qt.AspectRatioMode.KeepAspectRatioByExpanding,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        offset_x = avatar_rect.x() + (avatar_rect.width() - scaled.width()) // 2
+        offset_y = avatar_rect.y() + (avatar_rect.height() - scaled.height()) // 2
+        painter.drawPixmap(offset_x, offset_y, scaled)
+        painter.setClipping(False)
+
+        border_color = QColor('#00BD95') if icon_type == UserIcon.Type.Default else QColor('#8d8d8d')
+        painter.setPen(QPen(border_color, 6))
+        painter.setBrush(Qt.BrushStyle.NoBrush)
+        painter.drawEllipse(avatar_rect)
+
+        if icon_type == UserIcon.Type.Disable:
+            painter.setBrush(QColor(0, 0, 0, 135))
+            painter.setPen(Qt.PenStyle.NoPen)
+            painter.drawEllipse(avatar_rect)
+            UserIcon._draw_status_badge(painter, '🔒', QColor('#5f6368'))
+        elif icon_type == UserIcon.Type.Silence:
+            UserIcon._draw_status_badge(painter, '🔕', QColor('#d93025'))
+
+        if qtd > 0:
+            UserIcon._draw_notification_badge(painter, qtd)
+
+        painter.end()
+        return QIcon(pixmap)
+
+    @staticmethod
+    def _draw_status_badge(painter: QPainter, text: str, background: QColor):
+        badge_size = 42
+        x = 76
+        y = 76
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(background)
+        painter.drawEllipse(x, y, badge_size, badge_size)
+        painter.setPen(QColor('white'))
+        font = QFont('Sans Serif', 18)
+        painter.setFont(font)
+        painter.drawText(x, y + 1, badge_size, badge_size, int(Qt.AlignmentFlag.AlignCenter), text)
+
+    @staticmethod
+    def _draw_notification_badge(painter: QPainter, qtd: int):
+        text = '999+' if qtd > 999 else str(qtd)
+        badge_width = 52 if len(text) <= 2 else 68
+        badge_height = 36
+        x = 128 - badge_width - 2
+        y = 2
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(QColor('#d93025'))
+        painter.drawRoundedRect(x, y, badge_width, badge_height, 18, 18)
+        painter.setPen(QColor('white'))
+        font = QFont('Sans Serif', 15)
+        font.setBold(True)
+        painter.setFont(font)
+        painter.drawText(x, y, badge_width, badge_height, int(Qt.AlignmentFlag.AlignCenter), text)
 
     @staticmethod
     def _get_notification_data(qtd: int) -> dict:

--- a/zapzap/webengine/WebView.py
+++ b/zapzap/webengine/WebView.py
@@ -279,6 +279,7 @@ class WebView(QWebEngineView):
         (() => {
             const sampled = [];
             const seen = new Set();
+            const headerXPath = '//*[@id="app"]/div/div/div[3]/div/header';
 
             const addCandidate = (element) => {
                 let current = element;
@@ -293,9 +294,30 @@ class WebView(QWebEngineView):
                 }
             };
 
-            for (let x = 12; x <= 120; x += 18) {
-                for (let y = 12; y <= 120; y += 18) {
-                    document.elementsFromPoint(x, y).forEach(addCandidate);
+            const addXPathCandidates = () => {
+                const result = document.evaluate(
+                    headerXPath,
+                    document,
+                    null,
+                    XPathResult.FIRST_ORDERED_NODE_TYPE,
+                    null,
+                );
+                const header = result.singleNodeValue;
+                if (!header) {
+                    return false;
+                }
+
+                addCandidate(header);
+                header.querySelectorAll('*').forEach(addCandidate);
+                return true;
+            };
+
+            const hasHeader = addXPathCandidates();
+            if (!hasHeader) {
+                for (let x = 12; x <= 120; x += 18) {
+                    for (let y = 12; y <= 120; y += 18) {
+                        document.elementsFromPoint(x, y).forEach(addCandidate);
+                    }
                 }
             }
 
@@ -306,15 +328,17 @@ class WebView(QWebEngineView):
                 const src = tag === 'IMG' ? (element.currentSrc || element.src || '') : '';
                 const backgroundImage = style.backgroundImage || '';
                 const hasPaintedImage = Boolean(src) || (backgroundImage && backgroundImage !== 'none');
-                const withinSidebar = rect.left >= 0 && rect.top >= 0 && rect.left < window.innerWidth * 0.35 && rect.top < window.innerHeight * 0.35;
-                const visibleSize = rect.width >= 24 && rect.height >= 24 && rect.width <= 96 && rect.height <= 96;
-                const squareEnough = Math.abs(rect.width - rect.height) <= Math.max(10, rect.width * 0.4);
+                const withinSidebar = rect.left >= 0 && rect.top >= 0 && rect.left < window.innerWidth * 0.45 && rect.top < window.innerHeight * 0.35;
+                const visibleSize = rect.width >= 24 && rect.height >= 24 && rect.width <= 128 && rect.height <= 128;
+                const squareEnough = Math.abs(rect.width - rect.height) <= Math.max(10, rect.width * 0.45);
                 const borderRadius = parseFloat(style.borderTopLeftRadius || '0') || 0;
+                const fromXPathHeader = hasHeader && element.closest('header') !== null;
                 const score = (hasPaintedImage ? 1000 : 0)
                     + (withinSidebar ? 500 : 0)
                     + (squareEnough ? 150 : 0)
-                    + Math.max(0, 80 - Math.abs(rect.width - 40))
-                    + Math.max(0, 80 - Math.abs(rect.height - 40))
+                    + (fromXPathHeader ? 700 : 0)
+                    + Math.max(0, 100 - Math.abs(rect.width - 40))
+                    + Math.max(0, 100 - Math.abs(rect.height - 40))
                     + Math.min(borderRadius, 40)
                     - rect.top
                     - rect.left;
@@ -330,6 +354,7 @@ class WebView(QWebEngineView):
                     },
                     borderRadius: Math.round(borderRadius),
                     score,
+                    fromXPathHeader,
                     accepted: hasPaintedImage && withinSidebar && visibleSize && squareEnough,
                 };
             }).filter((candidate) => candidate.rect.width > 0 && candidate.rect.height > 0);
@@ -339,8 +364,9 @@ class WebView(QWebEngineView):
                 .sort((a, b) => b.score - a.score);
 
             return {
+                xpathFound: hasHeader,
                 best: accepted[0] || null,
-                inspected: candidates.slice(0, 20),
+                inspected: candidates.slice(0, 30),
                 acceptedCount: accepted.length,
             };
         })();

--- a/zapzap/webengine/WebView.py
+++ b/zapzap/webengine/WebView.py
@@ -20,6 +20,7 @@ from gettext import gettext as _
 
 class WebView(QWebEngineView):
     update_button_signal = pyqtSignal(int, int)  # Sinal para atualizar botões
+    update_button_photo_signal = pyqtSignal(int, str)
 
     QWEBENGINE_CACHE_TYPES = {
         "MemoryHttpCache": QWebEngineProfile.HttpCacheType.MemoryHttpCache,
@@ -49,6 +50,7 @@ class WebView(QWebEngineView):
         self._devtools_page = None
 
         self._last_tmp_file = None
+        self._avatar_sync_attempts = 0
 
         if user.enable:
             self._initialize()
@@ -258,6 +260,74 @@ class WebView(QWebEngineView):
             self.timer.timeout.connect(self.load_page)
             self.timer.setSingleShot(True)
             self.timer.start(5000)  # 5000 ms = 5 seconds
+            return
+
+        self._avatar_sync_attempts = 0
+        self._schedule_avatar_sync(2500)
+
+    def _schedule_avatar_sync(self, delay_ms=2500):
+        """Agenda tentativas para extrair a foto do perfil do WhatsApp Web."""
+        QTimer.singleShot(delay_ms, self._sync_page_button_photo)
+
+    def _sync_page_button_photo(self):
+        """Obtém a foto do perfil da conta e envia ao botão lateral."""
+        if not self.page():
+            return
+
+        script = r"""
+        (() => {
+            const candidates = [...document.querySelectorAll('img')].filter((img) => {
+                const src = img.currentSrc || img.src || '';
+                if (!src) return false;
+
+                const rect = img.getBoundingClientRect();
+                if (rect.width < 28 || rect.height < 28) return false;
+
+                const squareEnough = Math.abs(rect.width - rect.height) <= Math.max(8, rect.width * 0.35);
+                const upperSidebarArea = rect.top >= 0 && rect.top < window.innerHeight * 0.40 && rect.left >= 0 && rect.left < window.innerWidth * 0.35;
+                return squareEnough && upperSidebarArea;
+            });
+
+            if (!candidates.length) return '';
+
+            candidates.sort((a, b) => {
+                const ra = a.getBoundingClientRect();
+                const rb = b.getBoundingClientRect();
+                const scoreA = (ra.left < 220 ? 1000 : 0) - ra.top - Math.abs(ra.width - 40) - Math.abs(ra.height - 40);
+                const scoreB = (rb.left < 220 ? 1000 : 0) - rb.top - Math.abs(rb.width - 40) - Math.abs(rb.height - 40);
+                return scoreB - scoreA;
+            });
+
+            const img = candidates[0];
+            try {
+                const size = 128;
+                const canvas = document.createElement('canvas');
+                canvas.width = size;
+                canvas.height = size;
+                const ctx = canvas.getContext('2d');
+                ctx.beginPath();
+                ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
+                ctx.closePath();
+                ctx.clip();
+                ctx.drawImage(img, 0, 0, size, size);
+                return canvas.toDataURL('image/png');
+            } catch (error) {
+                return '';
+            }
+        })();
+        """
+
+        self.page().runJavaScript(script, self._handle_synced_page_button_photo)
+
+    def _handle_synced_page_button_photo(self, photo_data_url):
+        """Atualiza o botão lateral com a foto extraída da página."""
+        if photo_data_url:
+            self.update_button_photo_signal.emit(self.page_index, photo_data_url)
+            return
+
+        self._avatar_sync_attempts += 1
+        if self._avatar_sync_attempts < 5:
+            self._schedule_avatar_sync(4000)
 
     def set_zoom_factor_page(self, factor=None):
         """Define ou ajusta o fator de zoom da página."""

--- a/zapzap/webengine/WebView.py
+++ b/zapzap/webengine/WebView.py
@@ -2,7 +2,7 @@ import shutil
 import os
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from PyQt6.QtWebEngineCore import QWebEngineProfile, QWebEngineSettings, QWebEnginePage, QWebEngineScript
-from PyQt6.QtCore import QUrl, pyqtSignal, QTimer
+from PyQt6.QtCore import QUrl, pyqtSignal, QTimer, QRect, QByteArray, QBuffer, QIODevice
 from PyQt6.QtWidgets import QApplication
 from PyQt6.QtGui import QAction
 
@@ -51,6 +51,7 @@ class WebView(QWebEngineView):
 
         self._last_tmp_file = None
         self._avatar_sync_attempts = 0
+        self._debug_page_button_photo = os.getenv("ZAPZAP_DEBUG_PAGE_BUTTON_PHOTO", "0") == "1"
 
         if user.enable:
             self._initialize()
@@ -266,67 +267,163 @@ class WebView(QWebEngineView):
         self._schedule_avatar_sync(2500)
 
     def _schedule_avatar_sync(self, delay_ms=2500):
-        """Agenda tentativas para extrair a foto do perfil do WhatsApp Web."""
+        """Agenda tentativas para localizar a foto do perfil da conta."""
         QTimer.singleShot(delay_ms, self._sync_page_button_photo)
 
     def _sync_page_button_photo(self):
-        """Obtém a foto do perfil da conta e envia ao botão lateral."""
+        """Localiza a área do avatar e recorta a foto direto do WebView renderizado."""
         if not self.page():
             return
 
         script = r"""
         (() => {
-            const candidates = [...document.querySelectorAll('img')].filter((img) => {
-                const src = img.currentSrc || img.src || '';
-                if (!src) return false;
+            const sampled = [];
+            const seen = new Set();
 
-                const rect = img.getBoundingClientRect();
-                if (rect.width < 28 || rect.height < 28) return false;
+            const addCandidate = (element) => {
+                let current = element;
+                let depth = 0;
+                while (current && depth < 3) {
+                    if (!seen.has(current)) {
+                        seen.add(current);
+                        sampled.push(current);
+                    }
+                    current = current.parentElement;
+                    depth += 1;
+                }
+            };
 
-                const squareEnough = Math.abs(rect.width - rect.height) <= Math.max(8, rect.width * 0.35);
-                const upperSidebarArea = rect.top >= 0 && rect.top < window.innerHeight * 0.40 && rect.left >= 0 && rect.left < window.innerWidth * 0.35;
-                return squareEnough && upperSidebarArea;
-            });
-
-            if (!candidates.length) return '';
-
-            candidates.sort((a, b) => {
-                const ra = a.getBoundingClientRect();
-                const rb = b.getBoundingClientRect();
-                const scoreA = (ra.left < 220 ? 1000 : 0) - ra.top - Math.abs(ra.width - 40) - Math.abs(ra.height - 40);
-                const scoreB = (rb.left < 220 ? 1000 : 0) - rb.top - Math.abs(rb.width - 40) - Math.abs(rb.height - 40);
-                return scoreB - scoreA;
-            });
-
-            const img = candidates[0];
-            try {
-                const size = 128;
-                const canvas = document.createElement('canvas');
-                canvas.width = size;
-                canvas.height = size;
-                const ctx = canvas.getContext('2d');
-                ctx.beginPath();
-                ctx.arc(size / 2, size / 2, size / 2, 0, Math.PI * 2);
-                ctx.closePath();
-                ctx.clip();
-                ctx.drawImage(img, 0, 0, size, size);
-                return canvas.toDataURL('image/png');
-            } catch (error) {
-                return '';
+            for (let x = 12; x <= 120; x += 18) {
+                for (let y = 12; y <= 120; y += 18) {
+                    document.elementsFromPoint(x, y).forEach(addCandidate);
+                }
             }
+
+            const candidates = sampled.map((element) => {
+                const rect = element.getBoundingClientRect();
+                const style = window.getComputedStyle(element);
+                const tag = element.tagName || '';
+                const src = tag === 'IMG' ? (element.currentSrc || element.src || '') : '';
+                const backgroundImage = style.backgroundImage || '';
+                const hasPaintedImage = Boolean(src) || (backgroundImage && backgroundImage !== 'none');
+                const withinSidebar = rect.left >= 0 && rect.top >= 0 && rect.left < window.innerWidth * 0.35 && rect.top < window.innerHeight * 0.35;
+                const visibleSize = rect.width >= 24 && rect.height >= 24 && rect.width <= 96 && rect.height <= 96;
+                const squareEnough = Math.abs(rect.width - rect.height) <= Math.max(10, rect.width * 0.4);
+                const borderRadius = parseFloat(style.borderTopLeftRadius || '0') || 0;
+                const score = (hasPaintedImage ? 1000 : 0)
+                    + (withinSidebar ? 500 : 0)
+                    + (squareEnough ? 150 : 0)
+                    + Math.max(0, 80 - Math.abs(rect.width - 40))
+                    + Math.max(0, 80 - Math.abs(rect.height - 40))
+                    + Math.min(borderRadius, 40)
+                    - rect.top
+                    - rect.left;
+
+                return {
+                    tag,
+                    srcKind: src ? 'img' : (backgroundImage && backgroundImage !== 'none' ? 'background' : 'none'),
+                    rect: {
+                        x: Math.round(rect.x),
+                        y: Math.round(rect.y),
+                        width: Math.round(rect.width),
+                        height: Math.round(rect.height),
+                    },
+                    borderRadius: Math.round(borderRadius),
+                    score,
+                    accepted: hasPaintedImage && withinSidebar && visibleSize && squareEnough,
+                };
+            }).filter((candidate) => candidate.rect.width > 0 && candidate.rect.height > 0);
+
+            const accepted = candidates
+                .filter((candidate) => candidate.accepted)
+                .sort((a, b) => b.score - a.score);
+
+            return {
+                best: accepted[0] || null,
+                inspected: candidates.slice(0, 20),
+                acceptedCount: accepted.length,
+            };
         })();
         """
 
-        self.page().runJavaScript(script, self._handle_synced_page_button_photo)
+        self.page().runJavaScript(script, self._handle_page_button_photo_probe)
 
-    def _handle_synced_page_button_photo(self, photo_data_url):
-        """Atualiza o botão lateral com a foto extraída da página."""
+    def _handle_page_button_photo_probe(self, probe_result):
+        """Recorta a área localizada do avatar e envia a imagem ao botão lateral."""
+        if self._debug_page_button_photo:
+            print(f"[page_button_photo] page={self.page_index} probe={probe_result}")
+
+        if not isinstance(probe_result, dict) or not probe_result.get("best"):
+            self._retry_page_button_photo_sync("no_candidate")
+            return
+
+        rect_data = probe_result["best"].get("rect") or {}
+        crop_rect = self._build_page_button_photo_rect(rect_data)
+        if crop_rect is None:
+            self._retry_page_button_photo_sync("invalid_rect")
+            return
+
+        screenshot = self.grab()
+        if screenshot.isNull():
+            self._retry_page_button_photo_sync("null_screenshot")
+            return
+
+        cropped = screenshot.copy(crop_rect)
+        if cropped.isNull():
+            self._retry_page_button_photo_sync("null_crop")
+            return
+
+        photo_data_url = self._pixmap_to_data_url(cropped)
         if photo_data_url:
+            if self._debug_page_button_photo:
+                print(f"[page_button_photo] page={self.page_index} rect={crop_rect.getRect()} synced")
             self.update_button_photo_signal.emit(self.page_index, photo_data_url)
             return
 
+        self._retry_page_button_photo_sync("encode_failed")
+
+    def _build_page_button_photo_rect(self, rect_data):
+        """Normaliza o retângulo retornado pelo JS para recorte em pixels do WebView."""
+        try:
+            x = int(rect_data.get("x", 0))
+            y = int(rect_data.get("y", 0))
+            width = int(rect_data.get("width", 0))
+            height = int(rect_data.get("height", 0))
+        except (TypeError, ValueError, AttributeError):
+            return None
+
+        if width <= 0 or height <= 0:
+            return None
+
+        size = max(width, height)
+        pad = max(2, int(size * 0.08))
+        rect = QRect(x - pad, y - pad, size + (pad * 2), size + (pad * 2))
+        rect = rect.intersected(self.rect())
+        return rect if not rect.isEmpty() else None
+
+    def _pixmap_to_data_url(self, pixmap):
+        """Converte um QPixmap em data URL PNG."""
+        payload = QByteArray()
+        buffer = QBuffer(payload)
+        if not buffer.open(QIODevice.OpenModeFlag.WriteOnly):
+            return None
+
+        if not pixmap.save(buffer, "PNG"):
+            buffer.close()
+            return None
+
+        buffer.close()
+        encoded = bytes(payload.toBase64()).decode("ascii")
+        return f"data:image/png;base64,{encoded}"
+
+    def _retry_page_button_photo_sync(self, reason):
+        """Reagenda a sincronização da foto do botão com logs opcionais."""
         self._avatar_sync_attempts += 1
-        if self._avatar_sync_attempts < 5:
+        if self._debug_page_button_photo:
+            print(
+                f"[page_button_photo] page={self.page_index} retry={self._avatar_sync_attempts} reason={reason}"
+            )
+        if self._avatar_sync_attempts < 6:
             self._schedule_avatar_sync(4000)
 
     def set_zoom_factor_page(self, factor=None):


### PR DESCRIPTION
### Motivation
- Improve sidebar UX by showing each account's WhatsApp profile photo on its `page_button` when available, while keeping existing notification and status badges.
- Fall back to the current generated SVG icons when a profile photo cannot be extracted.

### Description
- Extract profile images from WhatsApp Web after page load in `WebView` using a small injected JS snippet and expose them via a new signal `update_button_photo_signal` and retry logic (`_schedule_avatar_sync`, `_sync_page_button_photo`, `_handle_synced_page_button_photo`).
- Connect the new signal in `Browser` and add `update_page_button_photo(page_index, photo_data_url)` to forward the data URL to the corresponding sidebar button.
- Extend `PageButton` to store a `photo_data_url`, add `update_user_photo`, and prefer rendering the synced photo when present by calling `UserIcon.get_account_icon` (preserving notification count and status badges and existing tooltip/selection behavior).
- Add image-handling and painting helpers in `UserIcon` (`get_account_icon`, `_load_photo_pixmap`, `_build_photo_icon`, `_draw_status_badge`, `_draw_notification_badge`) to render circular avatars with borders and badges, and keep the SVG icon fallback.
- Modified files: `zapzap/webengine/WebView.py`, `zapzap/controllers/Browser.py`, `zapzap/controllers/PageButton.py`, `zapzap/resources/UserIcon.py`.

### Testing
- Ran `python -m compileall zapzap/controllers/PageButton.py zapzap/resources/UserIcon.py zapzap/webengine/WebView.py zapzap/controllers/Browser.py` and compilation completed successfully for the modified files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baa5f5fe00832b818359c05d06a160)