### PR TITLE
Add built-in Nord theme and inject it into WhatsApp Web on page load

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ ZapZap extends WhatsApp Web with additional features:
   - open customization folders directly
 - Supports many userstyle files (`.user.css`) by extracting WhatsApp-targeted `@-moz-document` blocks
 - Page actions: `Save`, `Save and reload`, `Reload`
+- Includes a built-in Nord palette theme (`zapzap/resources/themes/nord.css`) with light and dark variants automatically applied in WhatsApp Web
 
 Customization files are stored in the app local data path under:
 - `customizations/global/css`

--- a/zapzap/resources/themes/nord.css
+++ b/zapzap/resources/themes/nord.css
@@ -1,16 +1,11 @@
 /* ==UserStyle==
-@name         WhatsApp Nord Hybrid (Light + Dark)
+@name         WhatsApp Nord (Light + Dark)
 @version      20260328
 @namespace    https://userstyles.world/user/rafatosta
-@description  Nord Theme adaptativo (Dark + Light) estável
+@description  Tema Nord com variantes claras e escuras para WhatsApp Web.
 @license      MIT
 ==/UserStyle== */
 
-@-moz-document url-prefix("https://web.whatsapp.com/") {
-
-    /* =========================
-   🎨 BASE NORD (tokens)
-========================= */
     :root {
         /* Polar Night */
         --nord0: #2e3440;
@@ -24,53 +19,62 @@
         --nord6: #eceff4;
 
         /* Frost */
+        --nord7: #8fbcbb;
         --nord8: #88c0d0;
         --nord9: #81a1c1;
+        --nord10: #5e81ac;
 
         /* Aurora */
         --nord11: #bf616a;
         --nord14: #a3be8c;
     }
 
-    /* =========================
-   🌙 DARK MODE
-========================= */
+    /* Light theme (padrão) */
+    :root,
+    body:not(.dark) {
+        --bg-base: var(--nord6);
+        --bg-surface: var(--nord5);
+        --bg-surface-2: var(--nord4);
+        --bg-hover: #cdd6e4;
+
+        --fg-primary: var(--nord0);
+        --fg-secondary: var(--nord3);
+
+        --accent: var(--nord10);
+        --accent-hover: var(--nord9);
+        --message-out: #d8e8fb;
+    }
+
+    /* Dark theme (acionado por body.dark do app) */
+    body.dark {
+        --bg-base: var(--nord0);
+        --bg-surface: var(--nord1);
+        --bg-surface-2: var(--nord2);
+        --bg-hover: var(--nord3);
+
+        --fg-primary: var(--nord6);
+        --fg-secondary: var(--nord4);
+
+        --accent: var(--nord8);
+        --accent-hover: var(--nord7);
+        --message-out: #36506b;
+    }
+
+    /* Fallback para navegadores que respeitam esquema preferido */
     @media (prefers-color-scheme: dark) {
-        :root {
+        :root:not(.light) {
             --bg-base: var(--nord0);
             --bg-surface: var(--nord1);
             --bg-surface-2: var(--nord2);
             --bg-hover: var(--nord3);
-
             --fg-primary: var(--nord6);
             --fg-secondary: var(--nord4);
-
             --accent: var(--nord8);
-            --accent-hover: var(--nord9);
+            --accent-hover: var(--nord7);
+            --message-out: #36506b;
         }
     }
 
-    /* =========================
-   🌞 LIGHT MODE
-========================= */
-    @media (prefers-color-scheme: light) {
-        :root {
-            --bg-base: var(--nord6);
-            --bg-surface: var(--nord5);
-            --bg-surface-2: var(--nord4);
-            --bg-hover: #cfd6e2;
-
-            --fg-primary: var(--nord0);
-            --fg-secondary: var(--nord3);
-
-            --accent: #5e81ac;
-            --accent-hover: #81a1c1;
-        }
-    }
-
-    /* =========================
-   🧠 TOKENS WHATSAPP
-========================= */
     * {
         --background-default: var(--bg-base) !important;
         --conversation-panel-background: var(--bg-base) !important;
@@ -81,43 +85,32 @@
 
         --incoming-background: var(--bg-surface) !important;
         --incoming-background-deeper: var(--bg-surface-2) !important;
-
-        --outgoing-background: var(--accent-hover) !important;
+        --outgoing-background: var(--message-out) !important;
 
         --background-default-hover: var(--bg-surface-2) !important;
         --background-default-active: var(--bg-hover) !important;
 
-        /* TEXTO */
         --primary: var(--fg-primary) !important;
         --secondary: var(--fg-secondary) !important;
         --secondary-lighter: var(--fg-secondary) !important;
-
         --system-message-text: var(--fg-secondary) !important;
 
-        /* UI */
         --button-primary-background: var(--accent) !important;
         --button-primary-background-hover: var(--accent-hover) !important;
-
         --unread-marker-background: var(--accent) !important;
 
         --icon: var(--fg-secondary) !important;
-
         --WDS-accent: var(--accent) !important;
         --WDS-red-300: var(--nord11) !important;
         --WDS-green-300: var(--nord14) !important;
     }
 
-    /* =========================
-   🔥 FALLBACK CONTROLADO
-========================= */
-
-    /* fundo geral */
     body,
     #app {
         background-color: var(--bg-base) !important;
+        color: var(--fg-primary) !important;
     }
 
-    /* superfícies */
     header,
     footer,
     main,
@@ -126,25 +119,6 @@
         background-color: var(--bg-surface) !important;
     }
 
-    /* elementos com inline style */
-    div[style*="background"] {
-        background-color: var(--bg-surface) !important;
-    }
-
-    /* =========================
-   ✍️ TEXTO (ESTÁVEL)
-========================= */
-    body {
-        color: var(--fg-primary) !important;
-    }
-
-    [style*="background"] {
-        color: var(--fg-primary) !important;
-    }
-
-    /* =========================
-   🔘 INPUT / BOTÕES
-========================= */
     button,
     input,
     textarea {
@@ -152,28 +126,17 @@
         color: var(--fg-primary) !important;
     }
 
-    /* =========================
-   🔗 LINKS
-========================= */
     a {
         color: var(--accent) !important;
     }
 
-    /* =========================
-   🎯 ICONES
-========================= */
     svg {
         fill: var(--fg-secondary) !important;
     }
 
-    /* =========================
-   🛡️ PROTEÇÃO DE MÍDIA
-========================= */
     img,
     video,
     canvas {
         background: transparent !important;
         color: initial !important;
     }
-
-}

--- a/zapzap/webengine/PageController.py
+++ b/zapzap/webengine/PageController.py
@@ -2,6 +2,9 @@ from PyQt6.QtWebEngineCore import QWebEnginePage, QWebEngineSettings
 from PyQt6.QtCore import QUrl
 from PyQt6.QtGui import QDesktopServices
 
+import json
+from pathlib import Path
+
 from zapzap import __whatsapp_url__
 from zapzap.services.AddonsManager import AddonsManager
 from zapzap.services.CustomizationsManager import CustomizationsManager
@@ -219,6 +222,7 @@ class PageController(QWebEnginePage):
         if success:
             # Injeta os addons
             AddonsManager.inject_addons(self)
+            self._apply_builtin_nord_theme()
             self.apply_customizations()
 
             # Permite notificações automaticamente
@@ -227,6 +231,36 @@ class PageController(QWebEnginePage):
                 QWebEnginePage.Feature.Notifications,
                 QWebEnginePage.PermissionPolicy.PermissionGrantedByUser
             )
+
+
+    @staticmethod
+    def _load_builtin_nord_css() -> str:
+        """Carrega o CSS Nord embutido para aplicação direta na página."""
+        css_path = Path(__file__).resolve().parent.parent / "resources" / "themes" / "nord.css"
+        try:
+            return css_path.read_text(encoding="utf-8")
+        except OSError:
+            return ""
+
+    def _apply_builtin_nord_theme(self):
+        """Injeta o tema Nord diretamente no DOM do WhatsApp Web."""
+        css = self._load_builtin_nord_css()
+        if not css:
+            return
+
+        script = f"""
+            (function() {{
+                var id = 'zapzap-built-in-nord-theme';
+                var style = document.getElementById(id);
+                if (!style) {{
+                    style = document.createElement('style');
+                    style.id = id;
+                    document.head.appendChild(style);
+                }}
+                style.textContent = {json.dumps(css)};
+            }})();
+        """
+        self.runJavaScript(script)
 
     def apply_customizations(self):
         self.apply_custom_css()


### PR DESCRIPTION
### Motivation
- Provide a built-in Nord color palette (light + dark variants) so users can use a ready-made theme without importing files.
- Ensure the theme is automatically applied to WhatsApp Web when a page finishes loading so the UI matches the application appearance.

### Description
- Documented the new built-in theme in `README.md` and referenced the resource path `zapzap/resources/themes/nord.css`.
- Added `zapzap/resources/themes/nord.css` with consolidated CSS variables and explicit light/dark handling plus fallbacks for `prefers-color-scheme`.
- Updated `zapzap/webengine/PageController.py` to load the embedded CSS via `Path`/`json` and inject it into the page head on successful load using the new methods ` _load_builtin_nord_css` and `_apply_builtin_nord_theme`.
- Kept existing customization injection flow (`apply_custom_css`/`apply_custom_js`) and added the theme injection prior to applying customizations.

### Testing
- Ran the project's automated test suite with `pytest` and the tests completed successfully.
- Ran static checks/linting and no new linting errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c828878f80832bbd369b2f7d03eaa6)