### PR TITLE
[Portal] fix: display contact profile pictures in notifications sent from the Flatpak backend

### DIFF
--- a/zapzap/notifications/PortalNotificationBackend.py
+++ b/zapzap/notifications/PortalNotificationBackend.py
@@ -1,13 +1,19 @@
-from PyQt6.QtCore import QObject, pyqtSlot
+from pathlib import Path
+
+from PyQt6.QtCore import QObject, pyqtSlot, QByteArray, QMetaType
 from PyQt6.QtDBus import (
+    QDBusArgument,
     QDBusConnection,
     QDBusInterface,
     QDBusMessage,
+    QDBusVariant,
 )
 from PyQt6.QtWebEngineCore import QWebEngineNotification
 from PyQt6.QtWidgets import QApplication
 
 from zapzap.webengine import WebView
+from zapzap.notifications.FreedesktopNotificationBackend import IconRenderer
+from zapzap.services.SettingsManager import SettingsManager
 
 
 class PortalNotificationBackend(QObject):
@@ -29,7 +35,8 @@ class PortalNotificationBackend(QObject):
         self._pages = {}
 
         # Assume suporte completo inicialmente
-        self._supports_extended_fields = True
+        self._supports_icon_field = True
+        self._supports_extra_fields = True
 
         self.bus.connect(
             "org.freedesktop.portal.Desktop",
@@ -38,6 +45,7 @@ class PortalNotificationBackend(QObject):
             "ActionInvoked",
             self._on_action_invoked
         )
+
 
     # ---------------------------------------------------------
     # Notify with Dynamic Fallback
@@ -60,58 +68,127 @@ class PortalNotificationBackend(QObject):
             "body": message,
             "priority": "normal",
             "default-action": self.ACTION_FOCUS,
-            "default-action-target": page.page_index,
         }
 
-        extended_fields = {
-            "display-hint": "show-as-new",
-            "category": "im.received",
-        }
+        icon_field = {}
+        if self._supports_icon_field:
+            icon_data = self._get_icon_data(notification, title)
+            if icon_data:
+                icon_field = {
+                    "icon": self._create_icon_arg(icon_data)
+                }
 
-        # Primeira tentativa: payload completo
-        if self._supports_extended_fields:
-            payload = {**base_payload, **extended_fields}
-        else:
-            payload = base_payload
+        extra_fields = {}
+        if self._supports_extra_fields:
+            extra_fields = {
+                "display-hint": ["show-as-new"],
+                "category": "im.received",
+            }
 
-        reply = self.interface.call(
-            "AddNotification",
-            notification_id,
-            payload
-        )
+        attempts = []
 
-        # -------------------------------------------------
-        # Se falhar e ainda não testamos fallback:
-        # -------------------------------------------------
-        if (
-            reply.type() == QDBusMessage.MessageType.ErrorMessage
-            and self._supports_extended_fields
-        ):
-            print(
-                "[Portal] Extended notification fields not supported. "
-                "Falling back to minimal payload."
-            )
+        # First attempt: payload extended with icon and extra fields
+        if icon_field and extra_fields:
+            attempts.append((
+                {**base_payload, **icon_field, **extra_fields},
+                "[Portal] Notification payload extended with icon field and extra fields failed.",
+            ))
 
-            self._supports_extended_fields = False
+        # Second attempt: payload extended with only icon field
+        if icon_field:
+            attempts.append((
+                {**base_payload, **icon_field},
+                "[Portal] Notification payload extended with icon field failed.",
+            ))
 
-            # Segunda tentativa sem campos extras
+        # Third attempt: payload extended with only extra fields
+        if extra_fields:
+            attempts.append((
+                {**base_payload, **extra_fields},
+                "[Portal] Notification payload extended with extra fields failed.",
+            ))
+
+        # Fourth attempt: minimal payload
+        attempts.append((
+            base_payload,
+            "[Portal] Notification failed: {}",
+        ))
+
+        for payload, error_msg in attempts:
             reply = self.interface.call(
                 "AddNotification",
                 notification_id,
-                base_payload
+                self._build_dbus_variant_map(payload)
             )
 
-        # -------------------------------------------------
-        # Nunca quebrar o app
-        # -------------------------------------------------
-        if reply.type() == QDBusMessage.MessageType.ErrorMessage:
-            print(
-                "[Portal] Notification failed:",
-                reply.errorMessage()
-            )
-            return  # não lançar exceção
+            if (reply.type() != QDBusMessage.MessageType.ErrorMessage):
+                notification.show()
+                break
 
-        notification.show()
+            print(error_msg.format(reply.errorMessage()))
+
+        self._supports_icon_field = bool(icon_field) and icon_field.items() <= payload.items()
+        self._supports_extra_fields = bool(extra_fields) and extra_fields.items() <= payload.items()
+
+
+    def _build_dbus_variant_map(self, payload: dict):
+        arg = QDBusArgument()
+        arg.beginMap(
+            QMetaType.Type.QString.value,
+            QMetaType.fromName(b"QDBusVariant").id()
+        )
+
+        for key, value in payload.items():
+            arg.beginMapEntry()
+            arg.add(key)
+            arg.add(QDBusVariant(value))
+            arg.endMapEntry()
+
+        arg.endMap()
+        return arg
+
+
+    def _create_icon_arg(self, data: bytes):
+        arg = QDBusArgument()
+        arg.beginStructure()
+        # The recommended format for dynamic icon data is "file-descriptor".
+        # However, PyQt6/QtDBus cannot currently marshal the required nested
+        # variant(h) value for QDBusUnixFileDescriptor inside an (sv) structure.
+        # Workaround: send icon data using the deprecated "bytes" format until
+        # this is fixed upstream.
+        arg.add("bytes")
+        arg.add(QDBusVariant(QByteArray(data)))
+        arg.endStructure()
+        return arg
+
+
+    def _get_icon_data(
+        self,
+        notification: QWebEngineNotification,
+        title: str,
+    ):
+        try:
+            icon_path = IconRenderer.default_icon()
+            if SettingsManager.get("notification/show_photo", True):
+                icon_path = IconRenderer.from_notification_icon(
+                    notification.icon(),
+                    title
+                )
+
+            if not icon_path:
+                return None
+
+            data = Path(icon_path).read_bytes()
+
+            if not data:
+                return None
+
+            return data
+
+        except Exception as e:
+            print("[Portal] Failed to create notification icon:", e)
+            return None
+
 
     # ---------------------------------------------------------
     # Action Handling
@@ -119,13 +196,10 @@ class PortalNotificationBackend(QObject):
 
     @pyqtSlot(str, str, list)
     def _on_action_invoked(self, notification_id, action, parameters):
-
         if action != self.ACTION_FOCUS:
             return
 
         try:
-            page_index = parameters[0]
-
             app = QApplication.instance()
             if not app:
                 return
@@ -141,10 +215,11 @@ class PortalNotificationBackend(QObject):
             notification = self._notifications.get(notification_id)
             page = self._pages.get(notification_id)
 
-            main_window.browser.switch_to_page(
-                page,
-                main_window.browser.page_buttons[page_index]
-            )
+            if page is not None:
+                main_window.browser.switch_to_page(
+                    page,
+                    main_window.browser.page_buttons[page.page_index]
+                )
 
             if notification:
                 notification.click()


### PR DESCRIPTION
This PR fixes #584 by making notifications sent from the Flatpak backend to display the contact/avatar image on portals that support this feature.

To implement this, I first tried to use the recommended "file-descriptor" format for sending icon data through D-Bus. However, it seems PyQt6/QtDBus currently cannot marshal the required nested variant(h) value for QDBusUnixFileDescriptor inside an (sv) structure. Because of that, this PR was written using the "bytes" icon format as a workaround, even though it is deprecated by xdg-desktop-portal v2.

Once the PyQt6/QtDBus marshalling issue is fixed upstream, this implementation can be updated to use the "file-descriptor" format properly.

This patch was manually tested with a local Flatpak build on the following DEs, all running under Wayland:

- KDE Plasma
- GNOME
- Cinnamon
- COSMIC
- Xfce
- Budgie

In all of them:

- contact/avatar images appear in notifications sent from the Flatpak backend
- as usual, clicking a notification focuses ZapZap and opens the conversation
- the backend still displays the notification even if the icon payload is rejected, gracefully falling back to one without a dynamic icon