### PR TITLE
Fix Flatpak locale selection for translations

### DIFF
--- a/zapzap/services/TranslationManager.py
+++ b/zapzap/services/TranslationManager.py
@@ -1,5 +1,6 @@
 import gettext
 import os
+from PyQt6.QtCore import QLocale
 
 from zapzap import APP_PATH, __appname__
 
@@ -11,7 +12,41 @@ class TranslationManager:
 
     @staticmethod
     def apply():
-         # Define path to translation files
+        # Define path to translation files
         gettext.bindtextdomain(__appname__.lower(),
                             TranslationManager._locale_dir)
         gettext.textdomain(__appname__.lower())
+
+        locale_candidates = []
+
+        # Honor explicit env overrides first.
+        for env_name in ("LANGUAGE", "LC_ALL", "LC_MESSAGES", "LANG"):
+            raw_value = os.environ.get(env_name, "")
+            if not raw_value:
+                continue
+            for item in raw_value.split(":"):
+                locale = item.split(".", 1)[0].split("@", 1)[0].strip()
+                if locale:
+                    locale_candidates.append(locale)
+
+        # Flatpak may expose locale reliably through Qt even when env vars are odd.
+        qt_locale = QLocale.system().name()
+        if qt_locale:
+            locale_candidates.append(qt_locale)
+
+        # Keep order, remove duplicates.
+        seen = set()
+        normalized_candidates = []
+        for locale in locale_candidates:
+            if locale in seen:
+                continue
+            seen.add(locale)
+            normalized_candidates.append(locale)
+
+        translation = gettext.translation(
+            __appname__.lower(),
+            localedir=TranslationManager._locale_dir,
+            languages=normalized_candidates or None,
+            fallback=True,
+        )
+        translation.install()


### PR DESCRIPTION
### Motivation
- Flatpak users reported the UI selecting the wrong language (e.g. Spanish instead of French) because translation selection relied on implicit gettext behavior and incomplete environment variables.
- Make translation loading deterministic and able to use Qt-provided locale information in sandboxed environments where env vars may be unreliable.

### Description
- Import `QLocale` and collect ordered locale candidates from environment variables `LANGUAGE`, `LC_ALL`, `LC_MESSAGES`, and `LANG`.
- Append `QLocale.system().name()` as an additional candidate to improve detection in Flatpak sessions.
- Deduplicate candidates while preserving order and call `gettext.translation(..., languages=..., fallback=True)` with the resolved list, then `install()` the selected translation.
- Keep existing domain and locale directory binding with explicit translation installation to ensure predictable selection.

### Testing
- Ran `python -m py_compile zapzap/services/TranslationManager.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa7579b20832b85d8f56d30c1eb1e)