### PR TITLE
Fix teardown crashes on exit

### DIFF
--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -5,6 +5,7 @@ import argparse
 from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtCore import QUrl
 
+from zapzap.services.ThemeManager import ThemeManager
 from zapzap.services.SetupManager import SetupManager
 from zapzap.controllers.MainWindow import MainWindow
 from zapzap.controllers.OnboardingDialog import OnboardingDialog
@@ -84,9 +85,17 @@ def main():
     else:
         main_window.show()
 
-    # Start app
-    sys.exit(app.exec())
+    app.aboutToQuit.connect(ThemeManager.stop)
+    app.aboutToQuit.connect(main_window.browser.shutdown)
+
+    exit_code = app.exec()
+
+    # Defensive fallback for abnormal shutdown paths where aboutToQuit may not have run.
+    ThemeManager.stop()
+    main_window.browser.shutdown()
+
+    return exit_code
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/zapzap/controllers/Browser.py
+++ b/zapzap/controllers/Browser.py
@@ -1,6 +1,6 @@
-from PyQt6.QtCore import QEasingCurve, QParallelAnimationGroup, QPropertyAnimation, QUrl, Qt
-from PyQt6.QtWidgets import QWidget, QPushButton, QMessageBox, QApplication
-from PyQt6.QtGui import QAction, QDesktopServices, QPixmap
+from PyQt6.QtCore import QEasingCurve, QParallelAnimationGroup, QPropertyAnimation, Qt
+from PyQt6.QtWidgets import QWidget, QPushButton, QMessageBox
+from PyQt6.QtGui import QAction
 from zapzap.controllers.CardUser import CardUser
 from zapzap.controllers.PageButton import PageButton
 from zapzap.webengine.WebView import WebView
@@ -31,11 +31,15 @@ class Browser(QWidget, Ui_Browser):
         self._sidebar_expanded_width = max(50, self.browser_sidebar.maximumWidth())
         self._sidebar_animation_group = None
         self._last_active_webview = None
+        self._shutting_down = False
 
         self._initialize()
 
-    def __del__(self):
-        """Garante que todas as páginas sejam fechadas ao destruir o widget."""
+    def shutdown(self):
+        """Libera explicitamente as páginas WebEngine antes do QApplication ser destruído."""
+        if self._shutting_down:
+            return
+        self._shutting_down = True
         self.close_pages()
 
     # === Inicialização ===
@@ -177,10 +181,19 @@ class Browser(QWidget, Ui_Browser):
         """Remove uma página e seu botão correspondente."""
         button, page = self._find_button_and_page_by_user(user)
 
-        if button and page:
-            button.close()
-            del self.page_buttons[button.page_index]
+        if page:
+            self.pages.removeWidget(page)
+            page.shutdown()
             page.remove_files()
+            page.close()
+            page.setParent(None)
+            page.deleteLater()
+
+        if button:
+            del self.page_buttons[button.page_index]
+            button.close()
+            button.deleteLater()
+
         self._select_default_page()
         self._update_user_menu()
 
@@ -219,11 +232,21 @@ class Browser(QWidget, Ui_Browser):
     # === Funções Auxiliares ===
     def _find_button_and_page_by_user(self, user: User):
         """Busca o botão e a página correspondentes ao usuário."""
+        found_button = None
+        found_page = None
+
         for button in self.page_buttons.values():
             if button.user.id == user.id:
-                page = self.pages.widget(button.page_index)
-                return button, page
-        return None, None
+                found_button = button
+                break
+
+        for i in range(self.pages.count()):
+            page = self.pages.widget(i)
+            if isinstance(page, WebView) and page.user.id == user.id:
+                found_page = page
+                break
+
+        return found_button, found_page
 
     def _find_button_and_page_enabled(self):
         """Busca o primeiro botão e página habilitados."""
@@ -280,11 +303,22 @@ class Browser(QWidget, Ui_Browser):
 
     def close_pages(self):
         """Fecha e limpa todas as páginas existentes."""
-        for i in range(self.pages.count()):
-            if i == self.grid_page_index: continue
+        for i in reversed(range(self.pages.count())):
             page = self.pages.widget(i)
-            if page and hasattr(page, '__del__'):
-                page.__del__()
+
+            if not isinstance(page, WebView):
+                continue
+
+            page.shutdown()
+            self.pages.removeWidget(page)
+            page.setParent(None)
+            page.deleteLater()
+
+        for button in list(self.page_buttons.values()):
+            button.close()
+            button.deleteLater()
+
+        self.page_buttons.clear()
 
     def reload_pages(self):
         """Recarrega todas as páginas existentes."""

--- a/zapzap/controllers/MainWindow.py
+++ b/zapzap/controllers/MainWindow.py
@@ -264,7 +264,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         if not SettingsManager.get("system/quit_in_close", False) and event:
             self._prepare_for_background(event)
         else:
-            self._clean_up_and_exit()
+            # Cleanup is handled by aboutToQuit() in __main__.py.
+            QApplication.instance().quit()
 
     def _save_window_state(self):
         """Salvar a geometria e o estado da janela."""
@@ -281,11 +282,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.browser.close_conversations()
         self.hide()
         event.ignore()
-
-    def _clean_up_and_exit(self):
-        """Limpar recursos e sair do aplicativo."""
-        self.browser.__del__()
-        QApplication.instance().quit()
 
     # === Controle de Visibilidade da Janela ===
     def show_window(self):

--- a/zapzap/services/ThemeManager.py
+++ b/zapzap/services/ThemeManager.py
@@ -32,10 +32,20 @@ class ThemeManager:
             self.current_theme = ThemeManager.Type(
                 SettingsManager.get("system/theme", ThemeManager.Type.Auto)
             )
-            self.timer = QTimer()
+            self.timer = QTimer(QApplication.instance())
             # Verifica o tema do sistema a cada segundo
             self.timer.setInterval(1000)
             self.timer.timeout.connect(self.sync_system_theme)
+
+    @staticmethod
+    def stop():
+        instance = ThemeManager._instance
+        if instance and instance.timer:
+            instance.timer.stop()
+            try:
+                instance.timer.timeout.disconnect(instance.sync_system_theme)
+            except TypeError:
+                pass
 
     # === Métodos Públicos ===
     @staticmethod

--- a/zapzap/webengine/WebView.py
+++ b/zapzap/webengine/WebView.py
@@ -44,17 +44,32 @@ class WebView(QWebEngineView):
         self.page_index = page_index
         self.profile = None  # Inicializa o perfil como None
         self._gesture_filter_installed = False
+        self.whatsapp_page = None
+
+        self._cache_path = None
+        self._storage_path = None
 
         self.notifications = NotificationService()
         self._devtools_view = None
         self._devtools_page = None
 
         self._last_tmp_file = None
+        self._shutting_down = False
+
+        self._reload_timer = QTimer(self)
+        self._reload_timer.setSingleShot(True)
+        self._reload_timer.timeout.connect(self.load_page)
+
+        self._render_crash_reload_timer = QTimer(self)
+        self._render_crash_reload_timer.setSingleShot(True)
+        self._render_crash_reload_timer.timeout.connect(self.load_page)
+
+        self._signals_configured = False
 
         if user.enable:
             self._initialize()
 
-    def __del__(self):
+    def _save_zoom_factor(self):
         try:
             if self.user and not self.isHidden():
                 self.user.zoomFactor = self.zoomFactor()
@@ -78,12 +93,18 @@ class WebView(QWebEngineView):
 
     def _configure_signals(self):
         """Configura os sinais para eventos."""
+        if self._signals_configured:
+            return
         self.titleChanged.connect(self._on_title_changed)
         self.loadFinished.connect(self._on_load_finished)
+        self._signals_configured = True
 
     def _configure_profile(self):
         """Configura o perfil do QWebEngine."""
         self.profile = QWebEngineProfile(str(self.user.id), self)
+
+        self._cache_path = self.profile.cachePath()
+        self._storage_path = self.profile.persistentStoragePath()
 
         selected_ua_name = SettingsManager.get(f"{self.user.id}/user_agent", "Default")
         ua_string = self.USER_AGENTS.get(selected_ua_name, self.USER_AGENTS["Default"])
@@ -153,8 +174,10 @@ class WebView(QWebEngineView):
         self.setZoomFactor(self.user.zoomFactor)
 
     def _on_render_crash(self, terminationStatus, exitCode):
+        if self._shutting_down or not self.user.enable or not self.whatsapp_page:
+            return
         print(f"Tab renderer crashed (status={terminationStatus}, code={exitCode}). Reloading...")
-        QTimer.singleShot(1000, self.load_page)
+        self._render_crash_reload_timer.start(1000)
 
     def contextMenuEvent(self, event):
         """Cria o menu de contexto personalizado ao clicar com o botão direito."""
@@ -261,12 +284,11 @@ class WebView(QWebEngineView):
         self.update_button_signal.emit(self.page_index, qtd)
 
     def _on_load_finished(self, success):
+        if self._shutting_down or not self.user.enable or not self.whatsapp_page:
+            return
         if not success:
             print("You are not connected to the Internet.")
-            self.timer = QTimer(self)
-            self.timer.timeout.connect(self.load_page)
-            self.timer.setSingleShot(True)
-            self.timer.start(5000)  # 5000 ms = 5 seconds
+            self._reload_timer.start(5000)
 
     def event(self, event):
         """Intercept native gesture events to optionally disable pinch-to-zoom.
@@ -300,7 +322,10 @@ class WebView(QWebEngineView):
 
     def load_page(self):
         """Carrega a página do WhatsApp."""
-        if self.user.enable:
+        if self._shutting_down:
+            return
+
+        if self.user.enable and self.whatsapp_page:
             self.setPage(self.whatsapp_page)
             self.load(QUrl(__whatsapp_url__))
             self.setZoomFactor(self.user.zoomFactor)
@@ -311,51 +336,111 @@ class WebView(QWebEngineView):
 
     def close_conversation(self):
         """Simula o pressionamento da tecla 'Escape' na página."""
-        if self.user.enable:
+        if self.user.enable and self.whatsapp_page:
             self.whatsapp_page.close_conversation()
 
     def set_theme_light(self):
         """Define o tema claro na página."""
-        if self.user.enable:
+        if self.user.enable and self.whatsapp_page:
             self.whatsapp_page.set_theme_light()
 
     def set_theme_dark(self):
         """Define o tema escuro na página."""
-        if self.user.enable:
+        if self.user.enable and self.whatsapp_page:
             self.whatsapp_page.set_theme_dark()
 
     def remove_files(self):
         """Remove os arquivos de cache e armazenamento persistente do perfil."""
-        try:
-            if not self.user.enable:
-                self.profile = QWebEngineProfile(str(self.user.id), self)
+        # TODO: refatorar a lógica de limpeza de cache de contas excluídas
+        # É mais seguro executar a limpeza em um momento menos crítico (próxima
+        # inicialização do aplicativo) do que durante a exclusão do perfil.
+        # Isso poderia ser feito, talvez, armazenando self._cache_path e
+        # self._storage_path por meio do objeto User.
+        if self._cache_path:
+            shutil.rmtree(self._cache_path, ignore_errors=True)
+            self._cache_path = None
 
-            cache_path = self.profile.cachePath()
-            storage_path = self.profile.persistentStoragePath()
-
-            shutil.rmtree(cache_path, ignore_errors=True)
-            shutil.rmtree(storage_path, ignore_errors=True)
-
-            self.stop()
-            self.close()
-            return True
-        except Exception as e:
-            return False
+        if self._storage_path:
+            shutil.rmtree(self._storage_path, ignore_errors=True)
+            self._storage_path = None
 
     def enable_page(self):
         """Ativa a página, configurando novamente."""
-        self._initialize()
+        if self._shutting_down:
+            return
+
+        if self.whatsapp_page is None and self.profile is None:
+            self._initialize()
+
         self.setVisible(True)
 
     def disable_page(self):
         """Desativa a página e limpa o perfil."""
+        if self._shutting_down:
+            return
+
+        self._teardown_webengine(clear_cache=True)
+
+    def shutdown(self):
+        if self._shutting_down:
+            return
+
+        self._shutting_down = True
+        self._teardown_webengine(clear_cache=False)
+
+    def _stop_timers(self):
+        for timer in (
+                getattr(self, "_reload_timer", None),
+                getattr(self, "_render_crash_reload_timer", None),
+        ):
+            if timer:
+                timer.stop()
+
+    def _teardown_webengine(self, clear_cache: bool=False):
+        """Destrói objetos Qt associados à WebEngine de forma ordenada."""
+        self._stop_timers()
+        self._save_zoom_factor()
+        self.stop()
+
         if self._gesture_filter_installed:
-            QApplication.instance().removeEventFilter(self)
+            app = QApplication.instance()
+            if app:
+                app.removeEventFilter(self)
             self._gesture_filter_installed = False
+
+        page = self.whatsapp_page
+        if page:
+            try:
+                page.setDevToolsPage(None)
+                self.setPage(None)
+                page.deleteLater()
+            except RuntimeError:
+                pass
+            finally:
+                self.whatsapp_page = None
+
+        if self._devtools_view:
+            try:
+                self._devtools_view.setPage(None)
+                self._devtools_view.close()
+                self._devtools_view.deleteLater()
+            except RuntimeError:
+                pass
+            finally:
+                self._devtools_view = None
+                self._devtools_page = None
+
         if self.profile:
-            crash_handler.unregister_profile(self.profile)
-            self.profile.clearHttpCache()
-        self.setPage(None)
+            try:
+                crash_handler.unregister_profile(self.profile)
+                if clear_cache:
+                    self.profile.clearHttpCache()
+                self.profile.deleteLater()
+            except RuntimeError:
+                pass
+            finally:
+                self.profile = None
+
         self.setVisible(False)
 
     def open_devtools(self):


### PR DESCRIPTION
This PR fixes #670 by addressing several teardown/lifetime issues that could contribute to crashes during application exit.

The most relevant changes are: replacing `__del__()`-based cleanup with explicit shutdown methods, centralizing application shutdown through `QApplication.aboutToQuit`, reworking the `WebEngine` teardown path, and adding multiple safeguards around cleanup-related methods and deferred callbacks.