### PR TITLE
fix: add missing folder to POTFILES

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,3 +2,4 @@
 ./zapzap/controllers/
 ./zapzap/services/
 ./zapzap/debug/
+./zapzap/webengine/


### PR DESCRIPTION
zapzap/webengine/WebView.py contains localizable strings, but zapzap/webengine is currently not present in the po/POTFILES file. This PR fixes this issue.