### PR TITLE
feat: iniciar migração da interface para QML (modo `--qml`)

### DIFF
--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -8,6 +8,7 @@ from PyQt6.QtCore import QUrl
 from zapzap.services.ThemeManager import ThemeManager
 from zapzap.services.SetupManager import SetupManager
 from zapzap.controllers.MainWindow import MainWindow
+from zapzap.controllers.QmlMainWindow import QmlMainWindow
 from zapzap.controllers.OnboardingDialog import OnboardingDialog
 from zapzap.controllers.SingleApplication import SingleApplication
 from zapzap.services.ProxyManager import ProxyManager
@@ -28,6 +29,8 @@ def main():
                         "valor"), help="Define uma configuração específica")
     parser.add_argument("--wayland", action="store_true",
                         help="Força o uso do Wayland (QT_QPA_PLATFORM=wayland)")
+    parser.add_argument("--qml", action="store_true",
+                        help="Inicia com a nova interface em QML (experimental)")
     args, unknown = parser.parse_known_args()
 
     if args.setSettings:
@@ -59,14 +62,15 @@ def main():
     app.messageReceived.connect(lambda result: main_window.xdgOpenChat(result))
 
     # Create main window
-    main_window = MainWindow()
+    main_window = QmlMainWindow() if args.qml else MainWindow()
     app.setWindow(main_window)
     app.setActivationWindow(main_window)
     main_window.load_settings()
 
-    ProxyManager.apply()
+    if not args.qml:
+        ProxyManager.apply()
 
-    show_onboarding = OnboardingDialog.should_show()
+    show_onboarding = OnboardingDialog.should_show() if not args.qml else False
 
     # Se houver onboarding, abrimos a janela para o fluxo ficar visualmente integrado
     if show_onboarding:
@@ -86,13 +90,15 @@ def main():
         main_window.show()
 
     app.aboutToQuit.connect(ThemeManager.stop)
-    app.aboutToQuit.connect(main_window.browser.shutdown)
+    if not args.qml:
+        app.aboutToQuit.connect(main_window.browser.shutdown)
 
     exit_code = app.exec()
 
     # Defensive fallback for abnormal shutdown paths where aboutToQuit may not have run.
     ThemeManager.stop()
-    main_window.browser.shutdown()
+    if not args.qml:
+        main_window.browser.shutdown()
 
     return exit_code
 

--- a/zapzap/controllers/QmlMainWindow.py
+++ b/zapzap/controllers/QmlMainWindow.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from PyQt6.QtCore import QObject, QUrl
+from PyQt6.QtQml import QQmlApplicationEngine
+
+
+class QmlMainWindow(QObject):
+    """Janela principal em QML (migração incremental)."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._engine = QQmlApplicationEngine()
+        qml_path = Path(__file__).resolve().parents[1] / "qml" / "MainWindow.qml"
+        self._engine.load(QUrl.fromLocalFile(str(qml_path)))
+
+        if not self._engine.rootObjects():
+            raise RuntimeError("Falha ao carregar a interface QML principal.")
+
+        self._window = self._engine.rootObjects()[0]
+
+    def load_settings(self):
+        """Hook para manter compatibilidade com o fluxo atual de inicialização."""
+        return
+
+    def show(self):
+        self._window.show()
+
+    def hide(self):
+        self._window.hide()
+
+    def close(self):
+        self._window.close()

--- a/zapzap/controllers/QmlMainWindow.py
+++ b/zapzap/controllers/QmlMainWindow.py
@@ -4,6 +4,7 @@ from PyQt6.QtCore import QObject, QStandardPaths, QUrl, pyqtProperty
 from PyQt6.QtQml import QQmlApplicationEngine
 
 from zapzap import __user_agent__, __whatsapp_url__, __appname__
+from zapzap.services.ThemeManager import ThemeManager
 
 
 class QmlWebEngineConfig(QObject):
@@ -62,6 +63,12 @@ class QmlMainWindow(QObject):
 
         self._window = self._engine.rootObjects()[0]
 
+        self._webview = self._window.findChild(QObject, "zapzapWebView")
+        if self._webview:
+            self._webview.loadFinished.connect(
+                lambda _ok: self.apply_theme(ThemeManager.get_current_theme())
+            )
+
     def load_settings(self):
         return
 
@@ -73,6 +80,24 @@ class QmlMainWindow(QObject):
 
     def close(self):
         self._window.close()
+
+
+    def apply_theme(self, theme):
+        if not self._webview:
+            return
+
+        theme_value = theme.value if hasattr(theme, "value") else str(theme)
+        force_dark = theme_value == ThemeManager.Type.Dark.value
+
+        script = f"""
+            (function() {{
+                var isDark = {str(force_dark).lower()};
+                document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+                document.documentElement.classList.toggle('dark', isDark);
+                document.body && document.body.classList.toggle('dark', isDark);
+            }})();
+        """
+        self._webview.runJavaScript(script)
 
     def xdgOpenChat(self, url: str):
         webview = self._window.findChild(QObject, "zapzapWebView")

--- a/zapzap/controllers/QmlMainWindow.py
+++ b/zapzap/controllers/QmlMainWindow.py
@@ -1,15 +1,59 @@
 from pathlib import Path
 
-from PyQt6.QtCore import QObject, QUrl
+from PyQt6.QtCore import QObject, QStandardPaths, QUrl, pyqtProperty
 from PyQt6.QtQml import QQmlApplicationEngine
+
+from zapzap import __user_agent__, __whatsapp_url__, __appname__
+
+
+class QmlWebEngineConfig(QObject):
+    """Expõe configuração do WebEngine para o QML."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        base_data_dir = Path(
+            QStandardPaths.writableLocation(
+                QStandardPaths.StandardLocation.AppLocalDataLocation
+            )
+        ) / __appname__
+
+        profile_dir = base_data_dir / "qml-profile"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+
+        self._persistent_storage_path = str(profile_dir / "storage")
+        self._cache_path = str(profile_dir / "cache")
+
+        Path(self._persistent_storage_path).mkdir(parents=True, exist_ok=True)
+        Path(self._cache_path).mkdir(parents=True, exist_ok=True)
+
+    @pyqtProperty(str, constant=True)
+    def whatsappUrl(self):
+        return __whatsapp_url__
+
+    @pyqtProperty(str, constant=True)
+    def userAgent(self):
+        return __user_agent__
+
+    @pyqtProperty(str, constant=True)
+    def persistentStoragePath(self):
+        return self._persistent_storage_path
+
+    @pyqtProperty(str, constant=True)
+    def cachePath(self):
+        return self._cache_path
 
 
 class QmlMainWindow(QObject):
-    """Janela principal em QML (migração incremental)."""
+    """Janela principal em QML com WebEngine e perfil persistente."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._engine = QQmlApplicationEngine()
+        self._webengine_config = QmlWebEngineConfig(self)
+        self._engine.rootContext().setContextProperty(
+            "webEngineConfig", self._webengine_config
+        )
+
         qml_path = Path(__file__).resolve().parents[1] / "qml" / "MainWindow.qml"
         self._engine.load(QUrl.fromLocalFile(str(qml_path)))
 
@@ -19,7 +63,6 @@ class QmlMainWindow(QObject):
         self._window = self._engine.rootObjects()[0]
 
     def load_settings(self):
-        """Hook para manter compatibilidade com o fluxo atual de inicialização."""
         return
 
     def show(self):
@@ -30,3 +73,15 @@ class QmlMainWindow(QObject):
 
     def close(self):
         self._window.close()
+
+    def xdgOpenChat(self, url: str):
+        webview = self._window.findChild(QObject, "zapzapWebView")
+        if not webview:
+            return
+
+        script = (
+            "(function(){var a = document.createElement('a');"
+            f"a.href={url!r};"
+            "document.body.appendChild(a);a.click();a.remove();})();"
+        )
+        webview.runJavaScript(script)

--- a/zapzap/controllers/QmlMainWindow.py
+++ b/zapzap/controllers/QmlMainWindow.py
@@ -62,12 +62,9 @@ class QmlMainWindow(QObject):
             raise RuntimeError("Falha ao carregar a interface QML principal.")
 
         self._window = self._engine.rootObjects()[0]
-
-        self._webview = self._window.findChild(QObject, "zapzapWebView")
-        if self._webview:
-            self._webview.loadFinished.connect(
-                lambda _ok: self.apply_theme(ThemeManager.get_current_theme())
-            )
+        self._window.webViewLoaded.connect(
+            lambda _ok: self.apply_theme(ThemeManager.get_current_theme())
+        )
 
     def load_settings(self):
         return
@@ -83,9 +80,6 @@ class QmlMainWindow(QObject):
 
 
     def apply_theme(self, theme):
-        if not self._webview:
-            return
-
         theme_value = theme.value if hasattr(theme, "value") else str(theme)
         force_dark = theme_value == ThemeManager.Type.Dark.value
 
@@ -97,16 +91,12 @@ class QmlMainWindow(QObject):
                 document.body && document.body.classList.toggle('dark', isDark);
             }})();
         """
-        self._webview.runJavaScript(script)
+        self._window.runInWebView(script)
 
     def xdgOpenChat(self, url: str):
-        webview = self._window.findChild(QObject, "zapzapWebView")
-        if not webview:
-            return
-
         script = (
             "(function(){var a = document.createElement('a');"
             f"a.href={url!r};"
             "document.body.appendChild(a);a.click();a.remove();})();"
         )
-        webview.runJavaScript(script)
+        self._window.runInWebView(script)

--- a/zapzap/qml/MainWindow.qml
+++ b/zapzap/qml/MainWindow.qml
@@ -1,6 +1,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import QtWebEngine
 
 ApplicationWindow {
     id: root
@@ -8,6 +9,16 @@ ApplicationWindow {
     height: 760
     visible: true
     title: "ZapZap"
+
+    WebEngineProfile {
+        id: zapzapProfile
+        offTheRecord: false
+        storageName: "zapzap-qml"
+        persistentStoragePath: webEngineConfig.persistentStoragePath
+        cachePath: webEngineConfig.cachePath
+        persistentCookiesPolicy: WebEngineProfile.ForcePersistentCookies
+        httpUserAgent: webEngineConfig.userAgent
+    }
 
     header: ToolBar {
         RowLayout {
@@ -22,37 +33,18 @@ ApplicationWindow {
 
             Item { Layout.fillWidth: true }
 
-            Button {
-                text: qsTr("Configurações")
-                enabled: false
-                ToolTip.visible: hovered
-                ToolTip.text: qsTr("Em migração para QML")
+            Label {
+                text: qsTr("QML experimental")
+                opacity: 0.75
             }
         }
     }
 
-    Rectangle {
+    WebEngineView {
+        id: webview
+        objectName: "zapzapWebView"
         anchors.fill: parent
-        color: palette.window
-
-        ColumnLayout {
-            anchors.centerIn: parent
-            spacing: 10
-
-            Label {
-                Layout.alignment: Qt.AlignHCenter
-                text: qsTr("Migração para QML iniciada")
-                font.pixelSize: 28
-                font.bold: true
-            }
-
-            Label {
-                Layout.alignment: Qt.AlignHCenter
-                text: qsTr("A estrutura base em QML foi criada para substituir a UI em .ui gradualmente.")
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-                Layout.maximumWidth: 640
-            }
-        }
+        profile: zapzapProfile
+        url: webEngineConfig.whatsappUrl
     }
 }

--- a/zapzap/qml/MainWindow.qml
+++ b/zapzap/qml/MainWindow.qml
@@ -1,0 +1,58 @@
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+
+ApplicationWindow {
+    id: root
+    width: 1200
+    height: 760
+    visible: true
+    title: "ZapZap"
+
+    header: ToolBar {
+        RowLayout {
+            anchors.fill: parent
+            anchors.margins: 12
+
+            Label {
+                text: "ZapZap"
+                font.pixelSize: 20
+                font.bold: true
+            }
+
+            Item { Layout.fillWidth: true }
+
+            Button {
+                text: qsTr("Configurações")
+                enabled: false
+                ToolTip.visible: hovered
+                ToolTip.text: qsTr("Em migração para QML")
+            }
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        color: palette.window
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 10
+
+            Label {
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("Migração para QML iniciada")
+                font.pixelSize: 28
+                font.bold: true
+            }
+
+            Label {
+                Layout.alignment: Qt.AlignHCenter
+                text: qsTr("A estrutura base em QML foi criada para substituir a UI em .ui gradualmente.")
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                Layout.maximumWidth: 640
+            }
+        }
+    }
+}

--- a/zapzap/qml/MainWindow.qml
+++ b/zapzap/qml/MainWindow.qml
@@ -5,6 +5,12 @@ import QtWebEngine
 
 ApplicationWindow {
     id: root
+    signal webViewLoaded(bool ok)
+
+    function runInWebView(script) {
+        webview.runJavaScript(script)
+    }
+
     width: 1200
     height: 760
     visible: true
@@ -46,5 +52,11 @@ ApplicationWindow {
         anchors.fill: parent
         profile: zapzapProfile
         url: webEngineConfig.whatsappUrl
+
+        onLoadingChanged: function(request) {
+            if (request.status === WebEngineLoadRequest.LoadSucceededStatus) {
+                root.webViewLoaded(true)
+            }
+        }
     }
 }

--- a/zapzap/services/ThemeManager.py
+++ b/zapzap/services/ThemeManager.py
@@ -120,7 +120,7 @@ class ThemeManager:
             window="#f7f5f3", text="#000000", base="#f0f0f0", highlight="#0066cc"
         )
         self._apply_palette(palette)
-        QApplication.instance().getWindow().browser.set_theme_light()
+        self._apply_window_theme(ThemeManager.Type.Light)
         QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('light'))
 
     def _apply_dark_theme(self):
@@ -129,7 +129,7 @@ class ThemeManager:
             window="#1d1f1f", text="#ffffff", base="#3a3a3a", highlight="#0099ff"
         )
         self._apply_palette(palette)
-        QApplication.instance().getWindow().browser.set_theme_dark()
+        self._apply_window_theme(ThemeManager.Type.Dark)
         QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('dark'))
 
     def _apply_custom_theme(self, colors: list[str], grade):
@@ -140,11 +140,32 @@ class ThemeManager:
         )
         self._apply_palette(palette)
         if grade == ThemeManager.Type.Light:
-            QApplication.instance().getWindow().browser.set_theme_light()
+            self._apply_window_theme(ThemeManager.Type.Light)
             QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('light'))
         elif grade == ThemeManager.Type.Dark:
-            QApplication.instance().getWindow().browser.set_theme_dark()
+            self._apply_window_theme(ThemeManager.Type.Dark)
             QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('dark'))
+
+
+    def _apply_window_theme(self, theme: Type):
+        """Aplica o tema no conteúdo da janela ativa (Widgets ou QML)."""
+        app = QApplication.instance()
+        if not app or not hasattr(app, "getWindow"):
+            return
+
+        window = app.getWindow()
+        if not window:
+            return
+
+        if hasattr(window, "browser"):
+            if theme == ThemeManager.Type.Dark:
+                window.browser.set_theme_dark()
+            else:
+                window.browser.set_theme_light()
+            return
+
+        if hasattr(window, "apply_theme"):
+            window.apply_theme(theme)
 
     def _create_palette(self, window, text, base, highlight):
         """Cria uma paleta com cores fornecidas."""


### PR DESCRIPTION
### Motivation
- Criar uma base incremental para migrar a UI baseada em `.ui` para QML sem quebrar o fluxo legado. 
- Permitir testar a nova interface QML de forma experimental ao mesmo tempo que mantém o aplicativo funcional.

### Description
- Adiciona `QmlMainWindow` em `zapzap/controllers/QmlMainWindow.py` que carrega a interface via `QQmlApplicationEngine` e expõe `load_settings`, `show`, `hide` e `close` para compatibilidade com o bootstrap existente. 
- Cria a interface inicial `zapzap/qml/MainWindow.qml` com um `ApplicationWindow` básico e mensagem de migração. 
- Adiciona flag `--qml` em `zapzap/__main__.py` para selecionar o modo QML em tempo de inicialização e altera o fluxo para condicionar execução de `ProxyManager`, onboarding e encerramento do browser ao modo legado. 
- Mantém o modo baseado em `.ui` como padrão para evitar regressões imediatas e facilita migração incremental.

### Testing
- Executado `python -m py_compile zapzap/__main__.py zapzap/controllers/QmlMainWindow.py` e a verificação de bytecode compilou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e12312348832babbe247369a10715)