### PR TITLE
Refactor theme manager and WhatsApp Web theme sync

### DIFF
--- a/ZapZap.spec
+++ b/ZapZap.spec
@@ -5,7 +5,13 @@ a = Analysis(
     ['zapzap\\__main__.py'],
     pathex=[],
     binaries=[],
-    datas=[('zapzap/po', 'zapzap/po'), ('zapzap/ui', 'zapzap/ui'), ('zapzap/resources', 'zapzap/resources'), ('zapzap/webengine/webrtc_shield.js', 'zapzap/webengine')],
+    datas=[
+        ('zapzap/po', 'zapzap/po'),
+        ('zapzap/ui', 'zapzap/ui'),
+        ('zapzap/resources', 'zapzap/resources'),
+        ('zapzap/webengine/webrtc_shield.js', 'zapzap/webengine'),
+        ('zapzap/webengine/theme_controller.js', 'zapzap/webengine')
+    ],
     hiddenimports=[],
     hookspath=[],
     hooksconfig={},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,8 @@ packages = [
 zapzap = [
   "po/*/LC_MESSAGES/*.mo",
   "js/*",
-  "extensions/*"
+  "extensions/*",
+  "webengine/*.js"
 ]
 
 [tool.setuptools.dynamic]

--- a/zapzap/__main__.py
+++ b/zapzap/__main__.py
@@ -58,6 +58,9 @@ def main():
     # Callback instance
     app.messageReceived.connect(lambda result: main_window.xdgOpenChat(result))
 
+    # Initialize ThemeManager
+    ThemeManager.start()
+
     # Create main window
     main_window = MainWindow()
     app.setWindow(main_window)

--- a/zapzap/controllers/Browser.py
+++ b/zapzap/controllers/Browser.py
@@ -3,6 +3,7 @@ from PyQt6.QtWidgets import QWidget, QPushButton, QMessageBox
 from PyQt6.QtGui import QAction
 from zapzap.controllers.CardUser import CardUser
 from zapzap.controllers.PageButton import PageButton
+from zapzap.services.ThemeManager import ThemeManager
 from zapzap.webengine.WebView import WebView
 from zapzap.models.User import User
 from zapzap.resources.SystemIcon import SystemIcon
@@ -52,6 +53,10 @@ class Browser(QWidget, Ui_Browser):
         self._select_default_page()
         self._update_user_menu()
         self.settings_sidebar()
+        self._update_buttons(
+            ThemeManager.get_current_theme(),
+            ThemeManager.get_current_color_scheme()
+        )
 
     def _setup_grid_view(self):
         from PyQt6.QtWidgets import QScrollArea, QGridLayout
@@ -86,7 +91,12 @@ class Browser(QWidget, Ui_Browser):
         self.btn_new_chat.clicked.connect(lambda: self.parent.new_chat())
         self.btn_open_settings.clicked.connect(
             lambda: self.parent.open_settings())
+        ThemeManager.instance().theme_changed.connect(self._update_buttons)
 
+    def _update_buttons(self, _current_theme, current_color_scheme):
+        self.__set_button_icons(
+            SystemIcon.Type[current_color_scheme.name]
+        )
 
     def _configure_flatpak_guidance(self):
         if not SetupManager._is_flatpak:
@@ -473,28 +483,6 @@ class Browser(QWidget, Ui_Browser):
         """Reseta os estilos de todos os botões."""
         for button in self.page_buttons.values():
             button.unselected()
-
-    def set_theme_light(self):
-        """Define o tema claro para as páginas e botões."""
-        # Define o tema claro para as páginas
-        for i in range(self.pages.count()):
-            if i == self.grid_page_index: continue
-            page = self.pages.widget(i)
-            page.set_theme_light()
-
-        # Define o tema claro para os botões
-        self.__set_button_icons(SystemIcon.Type.Light)
-
-    def set_theme_dark(self):
-        """Define o tema escuro para as páginas e botões."""
-        # Define o tema escuro para as páginas
-        for i in range(self.pages.count()):
-            if i == self.grid_page_index: continue
-            page = self.pages.widget(i)
-            page.set_theme_dark()
-
-        # Define o tema escuro para os botões
-        self.__set_button_icons(SystemIcon.Type.Dark)
 
     def __set_button_icons(self, theme):
         """Define os ícones dos botões com base no tema."""

--- a/zapzap/controllers/MainWindow.py
+++ b/zapzap/controllers/MainWindow.py
@@ -81,6 +81,7 @@ class MainWindow(QMainWindow, Ui_MainWindow):
             animated=False,
             persist=False,
         )
+        ThemeManager.instance().theme_changed.connect(self.refresh_theme_menu)
 
     def load_settings(self):
         """Restaura as configurações salvas da janela e do sistema."""
@@ -89,9 +90,8 @@ class MainWindow(QMainWindow, Ui_MainWindow):
         self.restoreState(SettingsManager.get(
             "main/windowState", QByteArray()))
 
-        # Exibe o SysTray e inicia o ThemeManager
+        # Exibe o SysTray
         SysTrayManager.start()
-        ThemeManager.start()
 
     def _setup_toolbar(self):
         """Ativa o toolBar com o menu de usuários (personalização futura)"""
@@ -151,7 +151,6 @@ class MainWindow(QMainWindow, Ui_MainWindow):
     def set_theme_mode(self, theme: ThemeManager.Type):
         """Aplica o tema selecionado pelo menu."""
         ThemeManager.set_theme(theme)
-        self.refresh_theme_menu()
 
     def refresh_theme_menu(self):
         """Sincroniza o estado do menu com a preferência de tema salva."""

--- a/zapzap/services/SystemThemeMonitor.py
+++ b/zapzap/services/SystemThemeMonitor.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from typing import Any
+from typing import cast
+
+from PyQt6.QtCore import QObject
+from PyQt6.QtCore import Qt
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtCore import pyqtSlot
+from PyQt6.QtDBus import QDBusConnection
+from PyQt6.QtDBus import QDBusInterface
+from PyQt6.QtDBus import QDBusMessage
+from PyQt6.QtDBus import QDBusVariant
+from PyQt6.QtGui import QStyleHints
+from PyQt6.QtWidgets import QApplication
+
+
+class SystemThemeMonitor(QObject):
+    """Monitors system color scheme changes.
+
+    Uses XDG Desktop Portal when available. Falls back to Qt style hints on
+    platforms or environments where the portal is unavailable.
+    """
+    SERVICE = "org.freedesktop.portal.Desktop"
+    PATH = "/org/freedesktop/portal/desktop"
+    INTERFACE = "org.freedesktop.portal.Settings"
+    NAMESPACE = "org.freedesktop.appearance"
+    KEY = "color-scheme"
+
+    color_scheme_changed = pyqtSignal(Qt.ColorScheme)
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._enabled = False
+        self._portal_monitoring = False
+        self._qt_style_hints_monitoring = False
+        self._current_color_scheme = type(self)._get_current_color_scheme()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, enabled: bool) -> None:
+        enabled = bool(enabled)
+
+        if self._enabled == enabled:
+            return
+
+        if enabled:
+            started = self._start_monitor()
+            if not started:
+                return
+        else:
+            self._stop_monitor()
+
+        self._enabled = enabled
+
+    # === Public methods === #
+    def get_current_color_scheme(self) -> Qt.ColorScheme:
+        return self._current_color_scheme
+
+    # === Common private methods === #
+    def _start_monitor(self) -> bool:
+        if self._portal_start_monitor():
+            return True
+
+        return self._qt_style_hints_start_monitor()
+
+    def _stop_monitor(self) -> None:
+        self._portal_stop_monitor()
+        self._qt_style_hints_stop_monitor()
+
+    def _report_color_scheme_changed(self, color_scheme: Qt.ColorScheme) -> None:
+        if color_scheme == self._current_color_scheme:
+            return
+
+        self._current_color_scheme = color_scheme
+        self.color_scheme_changed.emit(color_scheme)
+
+    @classmethod
+    def _get_current_color_scheme(cls) -> Qt.ColorScheme:
+        color_scheme = cls._portal_get_current_color_scheme()
+
+        if color_scheme in (Qt.ColorScheme.Dark, Qt.ColorScheme.Light):
+            return color_scheme
+
+        return cls._qt_style_hints_get_current_color_scheme()
+
+    # === Portal private methods === #
+    def _portal_start_monitor(self) -> bool:
+        if self._portal_monitoring:
+            return True
+
+        bus = QDBusConnection.sessionBus()
+
+        if not bus.isConnected():
+            return False
+
+        self._portal_monitoring = bus.connect(
+            "",
+            type(self).PATH,
+            type(self).INTERFACE,
+            "SettingChanged",
+            self._portal_color_scheme_changed,
+        )
+
+        return self._portal_monitoring
+
+    def _portal_stop_monitor(self) -> None:
+        if not self._portal_monitoring:
+            return
+
+        disconnected = QDBusConnection.sessionBus().disconnect(
+            "",
+            type(self).PATH,
+            type(self).INTERFACE,
+            "SettingChanged",
+            self._portal_color_scheme_changed,
+        )
+
+        if disconnected:
+            self._portal_monitoring = False
+
+    @classmethod
+    def _portal_get_current_color_scheme(cls) -> Qt.ColorScheme:
+        iface = QDBusInterface(
+            cls.SERVICE,
+            cls.PATH,
+            cls.INTERFACE,
+            QDBusConnection.sessionBus(),
+        )
+
+        reply = iface.call("Read", cls.NAMESPACE, cls.KEY)
+
+        if reply.type() == QDBusMessage.MessageType.ErrorMessage:
+            return Qt.ColorScheme.Unknown
+
+        args = reply.arguments()
+        if not args:
+            return Qt.ColorScheme.Unknown
+
+        return cls._portal_get_color_scheme_from_value(args[0])
+
+    @pyqtSlot(str, str, QDBusVariant)
+    def _portal_color_scheme_changed(
+        self,
+        namespace: str,
+        key: str,
+        value: QDBusVariant,
+    ) -> None:
+        if namespace != type(self).NAMESPACE:
+            return
+
+        if key != type(self).KEY:
+            return
+
+        color_scheme = type(self)._portal_get_color_scheme_from_value(value)
+        if color_scheme == Qt.ColorScheme.Unknown:
+            color_scheme = type(self)._portal_get_current_color_scheme()
+
+        self._report_color_scheme_changed(color_scheme)
+
+    @classmethod
+    def _portal_get_color_scheme_from_value(cls, value: Any) -> Qt.ColorScheme:
+        while isinstance(value, QDBusVariant):
+            value = value.variant()
+
+        try:
+            value = int(value)
+        except (TypeError, ValueError):
+            value = 0
+
+        return {
+            0: Qt.ColorScheme.Unknown,
+            1: Qt.ColorScheme.Dark,
+            2: Qt.ColorScheme.Light,
+        }.get(value, Qt.ColorScheme.Unknown)
+
+    # === Qt style hints private methods === #
+    @classmethod
+    def _qt_style_hints_get_style_hints(cls) -> QStyleHints | None:
+        app = cast(QApplication | None, QApplication.instance())
+        return app.styleHints() if app else None
+
+    def _qt_style_hints_start_monitor(self) -> bool:
+        if self._qt_style_hints_monitoring:
+            return True
+
+        style_hints = type(self)._qt_style_hints_get_style_hints()
+        if style_hints is None:
+            return False
+
+        style_hints.colorSchemeChanged.connect(
+            self._qt_style_hints_color_scheme_changed
+        )
+
+        self._qt_style_hints_monitoring = True
+        return True
+
+    def _qt_style_hints_stop_monitor(self) -> None:
+        if not self._qt_style_hints_monitoring:
+            return
+
+        style_hints = type(self)._qt_style_hints_get_style_hints()
+        if style_hints is None:
+            return
+
+        try:
+            style_hints.colorSchemeChanged.disconnect(
+                self._qt_style_hints_color_scheme_changed
+            )
+        except TypeError:
+            pass
+
+        self._qt_style_hints_monitoring = False
+
+    @classmethod
+    def _qt_style_hints_get_current_color_scheme(cls) -> Qt.ColorScheme:
+        style_hints = cls._qt_style_hints_get_style_hints()
+        if not style_hints:
+            return Qt.ColorScheme.Unknown
+
+        color_scheme = style_hints.colorScheme()
+        if color_scheme not in (Qt.ColorScheme.Light, Qt.ColorScheme.Dark):
+            return Qt.ColorScheme.Unknown
+
+        return color_scheme
+
+    def _qt_style_hints_color_scheme_changed(self, new_system_color_scheme: Qt.ColorScheme) -> None:
+        self._report_color_scheme_changed(new_system_color_scheme)

--- a/zapzap/services/ThemeManager.py
+++ b/zapzap/services/ThemeManager.py
@@ -1,154 +1,190 @@
-from PyQt6.QtCore import QTimer
-from PyQt6.QtDBus import QDBusInterface
-from PyQt6.QtWidgets import QApplication
-from PyQt6.QtGui import QPalette, QColor
+from __future__ import annotations
+
 from enum import Enum
+from typing import ClassVar
+from typing import cast
+
+from PyQt6.QtCore import QObject
+from PyQt6.QtCore import Qt
+from PyQt6.QtCore import pyqtSignal
+from PyQt6.QtGui import QColor
+from PyQt6.QtGui import QPalette
+from PyQt6.QtWidgets import QApplication
+
 from zapzap.resources.ThemeStylesheet import ThemeStylesheet
+from zapzap.services.SystemThemeMonitor import SystemThemeMonitor
 from zapzap.services.SettingsManager import SettingsManager
 
 
-class ThemeManager:
+class ThemeManager(QObject):
+    """Handles theme changes."""
     class Type(Enum):
         Auto = "auto"
         Light = "light"
         Dark = "dark"
-        Custom = "custom"
 
-    _instance = None
+    _LIGHT_PALETTE_COLORS = {
+        "window": "#f7f5f3",
+        "text": "#000000",
+        "base": "#f0f0f0",
+        "highlight": "#0066cc",
+    }
 
-    # Dicionário com temas
+    _DARK_PALETTE_COLORS = {
+        "window": "#1d1f1f",
+        "text": "#ffffff",
+        "base": "#3a3a3a",
+        "highlight": "#0099ff",
+    }
 
-    def __new__(cls, *args, **kwargs):
-        """Implementação do padrão Singleton."""
-        if not cls._instance:
-            cls._instance = super().__new__(cls)
-            cls._instance._initialized = False
-        return cls._instance
+    theme_changed = pyqtSignal(object, object)
 
-    def __init__(self):
-        """Inicializa o ThemeManager com as configurações do sistema."""
-        if not self._initialized:
-            self._initialized = True
-            self.current_theme = ThemeManager.Type(
-                SettingsManager.get("system/theme", ThemeManager.Type.Auto)
+    _instance: ClassVar[ThemeManager | None] = None
+    _creation_token: ClassVar[object] = object()
+
+    def __init__(self, token=None, parent=None):
+        """Initializes ThemeManager and loads theme settings."""
+        if token is not type(self)._creation_token:
+            raise RuntimeError(
+                "ThemeManager is a singleton. Call ThemeManager.instance() "
+                "instead of ThemeManager()."
             )
-            self.timer = QTimer(QApplication.instance())
-            # Verifica o tema do sistema a cada segundo
-            self.timer.setInterval(1000)
-            self.timer.timeout.connect(self.sync_system_theme)
+
+        super().__init__(parent)
+
+        self._current_color_scheme = Qt.ColorScheme.Unknown
+        self._last_emitted_theme_state = None
+        self._system_theme_monitor = SystemThemeMonitor(self)
+        self._system_color_scheme = self._get_effective_system_color_scheme()
+
+        self._system_theme_monitor.color_scheme_changed.connect(
+            self._on_system_color_scheme_changed
+        )
+
+        try:
+            theme = type(self).Type(
+                SettingsManager.get("system/theme", type(self).Type.Auto.value)
+            )
+        except ValueError:
+            # In case the legacy "custom" theme value is saved in the config file
+            theme = type(self).Type.Auto
+            SettingsManager.set("system/theme", theme.value)
+
+        self._current_theme = theme
+
+        self._update_system_theme_monitor_state()
+        self._apply_color_scheme()
+
+    @classmethod
+    def instance(cls) -> ThemeManager:
+        """Returns the ThemeManager singleton instance."""
+        # The singleton is enforced by a token instead of inside the __new__
+        # method to avoid messing with the PyQt QObject lifetime management.
+
+        if cls._instance is None:
+            cls._instance = cls(
+                token=cls._creation_token,
+                parent=cls._get_app_instance(),
+            )
+
+        return cast(ThemeManager, cls._instance)
 
     @staticmethod
-    def stop():
-        instance = ThemeManager._instance
-        if instance and instance.timer:
-            instance.timer.stop()
-            try:
-                instance.timer.timeout.disconnect(instance.sync_system_theme)
-            except TypeError:
-                pass
+    def _get_app_instance() -> QApplication | None:
+        return cast(QApplication | None, QApplication.instance())
 
-    # === Métodos Públicos ===
-    @staticmethod
-    def instance() -> 'ThemeManager':
-        """Obtém a instância singleton do ThemeManager."""
-        if ThemeManager._instance is None:
-            ThemeManager()
-        return ThemeManager._instance
+    def _get_theme_color_scheme(self, theme: Type) -> Qt.ColorScheme:
+        if theme == type(self).Type.Auto:
+            return self._system_color_scheme
 
-    @staticmethod
-    def start():
-        """Inicia o ThemeManager e sincroniza o tema com as configurações."""
-        instance = ThemeManager.instance()
-        if instance.current_theme == ThemeManager.Type.Auto:
-            instance.timer.start()
-            instance.sync_system_theme()
-        else:
-            instance._apply_theme()
+        return Qt.ColorScheme[theme.name]
 
-    @staticmethod
-    def set_theme(theme: Type):
-        """Define o tema de acordo com a preferência do usuário."""
-        instance = ThemeManager.instance()
-        # Salva o tema nas configurações
+    @classmethod
+    def start(cls) -> ThemeManager:
+        return cls.instance()
+
+    @classmethod
+    def stop(cls) -> None:
+        if cls._instance is None:
+            return
+
+        cls._instance._system_theme_monitor.enabled = False
+        cls._instance.deleteLater()
+        cls._instance = None
+
+    @classmethod
+    def set_theme(cls, theme: Type | str) -> None:
+        """Sets the ZapZap theme chosen by the user."""
+        instance = cls.instance()
+        theme = cls.Type(theme)
+
+        if instance._current_theme == theme:
+            return
+
         SettingsManager.set("system/theme", theme.value)
-        instance._set_user_theme(theme)
-        instance._refresh_window_theme_menu()
+
+        if theme == cls.Type.Auto:
+            instance._system_color_scheme = instance._get_effective_system_color_scheme()
+
+        instance._current_theme = theme
+        instance._update_system_theme_monitor_state()
+        instance._apply_color_scheme()
+
+    @classmethod
+    def get_current_theme(cls) -> Type:
+        """Returns the ZapZap theme currently selected by the user."""
+        return cls.instance()._current_theme
+
+    @classmethod
+    def get_current_color_scheme(cls) -> Qt.ColorScheme:
+        return cls.instance()._current_color_scheme
+
+    def _get_effective_system_color_scheme(self) -> Qt.ColorScheme:
+        color_scheme = self._system_theme_monitor.get_current_color_scheme()
+
+        if color_scheme == Qt.ColorScheme.Dark:
+            return Qt.ColorScheme.Dark
+
+        return Qt.ColorScheme.Light
+
+    def _apply_color_scheme(self) -> None:
+        current_color_scheme = self._get_theme_color_scheme(self._current_theme)
+        self._current_color_scheme = current_color_scheme
+        self._apply_palette_for_color_scheme(current_color_scheme)
+        self._emit_theme_changed(self._current_theme, current_color_scheme)
+
+    def _emit_theme_changed(
+        self,
+        current_theme: Type,
+        effective_color_scheme: Qt.ColorScheme
+    ) -> None:
+        theme_state = (current_theme, effective_color_scheme)
+
+        if self._last_emitted_theme_state != theme_state:
+            self.theme_changed.emit(current_theme, effective_color_scheme)
+            self._last_emitted_theme_state = theme_state
+
+    def _update_system_theme_monitor_state(self) -> None:
+        self._system_theme_monitor.enabled = (
+            self._current_theme == type(self).Type.Auto
+        )
+
+    def _on_system_color_scheme_changed(self, new_system_color_scheme: Qt.ColorScheme) -> None:
+        if new_system_color_scheme == Qt.ColorScheme.Unknown:
+            new_system_color_scheme = Qt.ColorScheme.Light
+
+        if new_system_color_scheme == self._system_color_scheme:
+            return
+
+        self._system_color_scheme = new_system_color_scheme
+
+        if self._current_theme == type(self).Type.Auto:
+            self._apply_color_scheme()
 
     @staticmethod
-    def get_current_theme() -> Type:
-        """Obtém o tema atual."""
-        return ThemeManager.instance().current_theme
-
-    @staticmethod
-    def sync():
-        """Força a sincronização do tema atual."""
-        instance = ThemeManager.instance()
-        instance._apply_theme()
-
-    # === Sincronização e Aplicação de Temas ===
-    def sync_system_theme(self):
-        """Sincroniza o tema do sistema com o tema atual."""
-        theme = self._detect_system_theme()
-        if self.current_theme != theme:
-            self.current_theme = theme
-            self._apply_theme()
-            self._refresh_window_theme_menu()
-
-    def _set_user_theme(self, theme: Type):
-        """Define o tema com base na escolha do usuário."""
-        if theme == ThemeManager.Type.Auto:
-            self.timer.start()
-        else:
-            self.timer.stop()
-            self.current_theme = theme
-            self._apply_theme()
-
-    def _apply_theme(self, colors: list[int] = None, grade=None):
-        """Aplica o tema atual."""
-        if self.current_theme == ThemeManager.Type.Light:
-            self._apply_light_theme()
-        elif self.current_theme == ThemeManager.Type.Dark:
-            self._apply_dark_theme()
-        elif self.current_theme == ThemeManager.Type.Custom:
-            # TODO: These colors should be passed from the settings interface
-            self._apply_custom_theme(colors, grade)
-
-    # === Implementação dos Temas Claro e Escuro ===
-    def _apply_light_theme(self):
-        """Aplica o tema claro."""
-        palette = self._create_palette(
-            window="#f7f5f3", text="#000000", base="#f0f0f0", highlight="#0066cc"
-        )
-        self._apply_palette(palette)
-        QApplication.instance().getWindow().browser.set_theme_light()
-        QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('light'))
-
-    def _apply_dark_theme(self):
-        """Aplica o tema escuro."""
-        palette = self._create_palette(
-            window="#1d1f1f", text="#ffffff", base="#3a3a3a", highlight="#0099ff"
-        )
-        self._apply_palette(palette)
-        QApplication.instance().getWindow().browser.set_theme_dark()
-        QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('dark'))
-
-    def _apply_custom_theme(self, colors: list[str], grade):
-        """Aplica o tema customizado."""
-        print("Aplicando tema customizado...")
-        palette = self._create_palette(
-            window=colors[0], text=colors[1], base=colors[2], highlight=colors[3]
-        )
-        self._apply_palette(palette)
-        if grade == ThemeManager.Type.Light:
-            QApplication.instance().getWindow().browser.set_theme_light()
-            QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('light'))
-        elif grade == ThemeManager.Type.Dark:
-            QApplication.instance().getWindow().browser.set_theme_dark()
-            QApplication.instance().setStyleSheet(ThemeStylesheet.get_stylesheet('dark'))
-
-    def _create_palette(self, window, text, base, highlight):
-        """Cria uma paleta com cores fornecidas."""
+    def _create_palette(window: str, text: str, base: str, highlight: str) -> QPalette:
         palette = QPalette()
+
         palette.setColor(QPalette.ColorRole.Window, QColor(window))
         palette.setColor(QPalette.ColorRole.WindowText, QColor(text))
         palette.setColor(QPalette.ColorRole.Base, QColor(base))
@@ -159,40 +195,20 @@ class ThemeManager:
         palette.setColor(QPalette.ColorRole.ButtonText, QColor(text))
         palette.setColor(QPalette.ColorRole.Highlight, QColor(highlight))
         palette.setColor(QPalette.ColorRole.HighlightedText, QColor(text))
+
         return palette
 
-    def _apply_palette(self, palette):
-        """Aplica a paleta ao aplicativo."""
-        QApplication.instance().setPalette(palette)
-
-    def _refresh_window_theme_menu(self):
-        """Atualiza o estado do menu de tema quando a janela principal existir."""
-        app = QApplication.instance()
-        if not app or not hasattr(app, "getWindow"):
+    @classmethod
+    def _apply_palette_for_color_scheme(cls, color_scheme: Qt.ColorScheme) -> None:
+        app = cls._get_app_instance()
+        if app is None:
             return
 
-        window = app.getWindow()
-        if window and hasattr(window, "refresh_theme_menu"):
-            window.refresh_theme_menu()
+        palette_colors = (
+            cls._DARK_PALETTE_COLORS
+            if color_scheme == Qt.ColorScheme.Dark
+            else cls._LIGHT_PALETTE_COLORS
+        )
 
-    # === Detecção do Tema do Sistema ===
-    def _detect_system_theme(self) -> Type:
-        """
-        Determina o tema do sistema usando a interface D-Bus.
-        Retorna:
-            - ThemeManager.Type.Dark se o tema escuro for preferido
-            - ThemeManager.Type.Light se o tema claro for preferido
-        """
-        try:
-            interface = QDBusInterface(
-                "org.freedesktop.portal.Desktop",
-                "/org/freedesktop/portal/desktop",
-                "org.freedesktop.portal.Settings",
-            )
-            msg = interface.call(
-                "Read", "org.freedesktop.appearance", "color-scheme")
-            color_scheme = msg.arguments()[0]
-            return ThemeManager.Type.Dark if color_scheme == 1 else ThemeManager.Type.Light
-        except Exception as e:
-            print(f"Erro ao obter o tema do sistema: {e}")
-            return ThemeManager.Type.Light
+        app.setPalette(cls._create_palette(**palette_colors))
+        app.setStyleSheet(ThemeStylesheet.get_stylesheet(color_scheme.name.lower()))

--- a/zapzap/webengine/PageController.py
+++ b/zapzap/webengine/PageController.py
@@ -1,4 +1,8 @@
-from PyQt6.QtWebEngineCore import QWebEnginePage, QWebEngineSettings
+from typing import cast
+
+from PyQt6.QtWebEngineCore import QWebEnginePage
+from PyQt6.QtWebEngineCore import QWebEngineSettings
+from PyQt6.QtCore import Qt
 from PyQt6.QtCore import QUrl
 from PyQt6.QtGui import QDesktopServices
 
@@ -6,8 +10,6 @@ from zapzap import __allowed_hosts__
 from zapzap.services.AddonsManager import AddonsManager
 from zapzap.services.CustomizationsManager import CustomizationsManager
 from zapzap.services.ThemeManager import ThemeManager
-from zapzap.services.SettingsManager import SettingsManager
-from zapzap.services.EnvironmentManager import EnvironmentManager, Packaging
 
 import urllib.parse  # Para normalizar URLs
 
@@ -17,14 +19,12 @@ from gettext import gettext as _
 class PageController(QWebEnginePage):
     """Controlador de página para gerenciar eventos e ações personalizadas no QWebEnginePage."""
 
-    APP_START = True
-    APP_LOAD = True
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.link_url = ""
         self.link_context = ''
         self.user_id = None
+        self._force_dark_mode_fallback_active = False
 
         # Conecta sinais para funcionalidades específicas
         self.linkHovered.connect(self._on_link_hovered)
@@ -85,77 +85,96 @@ class PageController(QWebEnginePage):
         script = """document.dispatchEvent(new KeyboardEvent("keydown", {'key': 'Escape'}));"""
         self.runJavaScript(script)
 
-    """
-    local -> inicar em modo Auto e Dark não atualiza a página
-    """
-
-    def apply_theme(self, system_theme: ThemeManager.Type):
-        """
-        Aplica o tema considerando:
-        - Configuração do usuário (Auto, Light, Dark)
-        - Tema do sistema (quando Auto)
-        - Ambiente (Flatpak vs local)
-        """
-
-        is_flatpak = EnvironmentManager.identify_packaging() == Packaging.FLATPAK
-
-        configured_theme = ThemeManager.Type(
-            SettingsManager.get("system/theme", ThemeManager.Type.Auto)
-        )
-
-        # Resolve o tema final
-        effective_theme = (
-            system_theme if configured_theme == ThemeManager.Type.Auto
-            else configured_theme
-        )
-
-        # --- REGRA ESPECIAL (Flatpak + Auto na inicialização) ---
-        if is_flatpak and self.APP_START and configured_theme == ThemeManager.Type.Auto:
-            self.APP_START = False
-            print("[Theme] Skip reload on startup (Flatpak + Auto)")
+    def apply_theme(
+        self,
+        _current_theme: ThemeManager.Type,
+        current_color_scheme: Qt.ColorScheme
+    ) -> None:
+        if self._force_dark_mode_fallback_active:
+            self.fall_back_to_force_dark_mode()
             return
 
-        if configured_theme == ThemeManager.Type.Auto:
-            if system_theme == ThemeManager.Type.Light:
-                self._set_force_dark(False)
-                self._apply_css_theme(ThemeManager.Type.Light)
-            else:
+        script = f"""
+            (() => {{
+                try {{
+                    if (typeof _zapZapWAWebThemeController === 'undefined') {{
+                        // Injection is still pending.
+                        return true;
+                    }}
 
-                if not is_flatpak and self.APP_LOAD:
-                    self._set_force_dark(True)
-                    self.APP_LOAD = False
-                else:
-                    self._set_force_dark(False)
-                    self._apply_css_theme(ThemeManager.Type.Dark)
+                    if (
+                        typeof _zapZapWAWebThemeController.has_failed !== 'function' ||
+                        typeof _zapZapWAWebThemeController.is_ready !== 'function' ||
+                        typeof _zapZapWAWebThemeController.applyZapZapColorSchemeToWAWeb !== 'function' ||
+                        _zapZapWAWebThemeController.has_failed()
+                    ) {{
+                        // Controller is unavailable or failed.
+                        return false;
+                    }}
 
-        if configured_theme == ThemeManager.Type.Light:
-            self._set_force_dark(False)
+                    if (!_zapZapWAWebThemeController.is_ready()) {{
+                        // Controller is still initializing.
+                        return true;
+                    }}
 
-        if configured_theme == ThemeManager.Type.Dark:
-            if not ThemeManager.instance()._detect_system_theme() == ThemeManager.Type.Dark or not is_flatpak:
-                self._set_force_dark(True)
+                    _zapZapWAWebThemeController.currentColorScheme = "{current_color_scheme.name.lower()}";
+                    return _zapZapWAWebThemeController.applyZapZapColorSchemeToWAWeb();
+                }} catch (e) {{
+                    console.error("[ZapZap WAWeb Theme Controller]", e);
+                    return false;
+                }}
+            }})()
+        """
+        self.runJavaScript(script, self.on_apply_theme_result)
 
-    def _set_force_dark(self, enabled: bool):
-        """Aplica ForceDark no engine."""
-        self.profile().settings().setAttribute(
-            QWebEngineSettings.WebAttribute.ForceDarkMode,
-            enabled
+    def on_apply_theme_result(self, result: bool, message: str | None = None) -> None:
+        if result:
+            return
+
+        if message is None:
+            message = "Unable to set the WhatsApp Web Theme via JavaScript"
+
+        print(
+            f'[ZapZap WAWeb Theme Controller] Controller #{self.parent().page_index} failed. '
+            f'{message.rstrip(".")}.'
         )
 
-    def _apply_css_theme(self, theme: ThemeManager.Type):
-        """Aplica tema via CSS (sem reload)."""
-        if theme == ThemeManager.Type.Dark:
-            self.runJavaScript("document.body.classList.add('dark');")
-        else:
-            self.runJavaScript("document.body.classList.remove('dark');")
+    def fall_back_to_force_dark_mode(self) -> None:
+        """Falls back to using ForceDarkMode to handle the WhatsApp Web Theme."""
+        from zapzap.webengine.WebView import WebView
 
-    def set_theme_light(self):
-        """Altera o tema da página para claro."""
-        self.apply_theme(ThemeManager.Type.Light)
+        profile = self.profile()
+        settings = profile.settings() if profile else None
 
-    def set_theme_dark(self):
-        """Altera o tema da página para escuro."""
-        self.apply_theme(ThemeManager.Type.Dark)
+        if not settings:
+            return
+
+        settings.setAttribute(
+            QWebEngineSettings.WebAttribute.ForceDarkMode,
+            (ThemeManager.get_current_color_scheme() == Qt.ColorScheme.Dark)
+        )
+
+        if self._force_dark_mode_fallback_active:
+            return
+
+        self._force_dark_mode_fallback_active = True
+        print(
+            f'[ZapZap WAWeb Theme Controller] Controller #{self.parent().page_index} '
+            'activated ForceDarkMode fallback.'
+        )
+
+        # Try to force WhatsApp Web to adopt the light theme by setting the related
+        # localStorage persistency values and reloading the page, since ForceDarkMode
+        # only works well if WAWeb is using its own light theme.
+        self.runJavaScript(
+            f'''(() => {{
+                localStorage["theme"] = JSON.stringify("{Qt.ColorScheme.Light.name.lower()}");
+                localStorage["system-theme-mode"] = JSON.stringify(false);
+            }})()'''
+        )
+        # Reload WhatsApp Web page to force it to load the theme settings saved
+        # in localStorage.
+        cast(WebView, cast(object, self.parent())).load_page()
 
     def new_chat(self):
         """Simula o atalho 'Ctrl+Alt+N' para iniciar um novo chat."""

--- a/zapzap/webengine/WebView.py
+++ b/zapzap/webengine/WebView.py
@@ -1,11 +1,15 @@
+import re
 import shutil
 import os
+
+from PyQt6.QtWebChannel import QWebChannel
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from PyQt6.QtWebEngineCore import QWebEngineProfile, QWebEngineSettings, QWebEnginePage, QWebEngineScript
-from PyQt6.QtCore import QUrl, pyqtSignal, QTimer, QEvent, Qt
+from PyQt6.QtCore import QUrl, pyqtSignal, QTimer, QEvent, Qt, QFile, QTextStream, QObject, pyqtSlot
 from PyQt6.QtWidgets import QApplication, QWidget
 from PyQt6.QtGui import QAction
 
+from zapzap.services.ThemeManager import ThemeManager
 from zapzap.webengine.PageController import PageController
 from zapzap.models import User
 from zapzap import __user_agent__, __whatsapp_url__
@@ -56,6 +60,8 @@ class WebView(QWebEngineView):
         self._last_tmp_file = None
         self._shutting_down = False
 
+        self._web_channel_bridge = None
+
         self._reload_timer = QTimer(self)
         self._reload_timer.setSingleShot(True)
         self._reload_timer.timeout.connect(self.load_page)
@@ -97,6 +103,7 @@ class WebView(QWebEngineView):
             return
         self.titleChanged.connect(self._on_title_changed)
         self.loadFinished.connect(self._on_load_finished)
+        ThemeManager.instance().theme_changed.connect(self.apply_theme)
         self._signals_configured = True
 
     def _configure_profile(self):
@@ -158,6 +165,78 @@ class WebView(QWebEngineView):
             except Exception as e:
                 print(f"Error injecting WebRTC shield: {e}")
 
+    def _inject_web_theme_controller(self):
+        """Injects the JavaScript code for the ZapZap WAWeb Theme Controller and QWebChannel support."""
+        self._setup_web_channel()
+
+        placeholders = {
+            "{qwebchannel_js_code}": self._get_web_channel_js_code(),
+            "{current_color_scheme}": ThemeManager.get_current_color_scheme().name.lower(),
+        }
+
+        base_dir = os.path.dirname(__file__)
+        js_path = os.path.join(base_dir, "theme_controller.js")
+        file = QFile(js_path)
+        if not file.open(QFile.OpenModeFlag.ReadOnly):
+            raise RuntimeError(file.errorString())
+        js_code = QTextStream(file).readAll()
+
+        pattern = re.compile("|".join(re.escape(key) for key in placeholders.keys()))
+        js_code = pattern.sub(lambda m: placeholders[m.group(0)], js_code)
+        try:
+            script = QWebEngineScript()
+            script.setName("zapzap_web_theme_controller")
+            script.setInjectionPoint(QWebEngineScript.InjectionPoint.DocumentReady)
+            script.setRunsOnSubFrames(False)
+            script.setSourceCode(js_code)
+            script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)
+            self.profile.scripts().insert(script)
+        except Exception as e:
+            print(f"Error injecting web theme controller: {e}")
+
+    def _setup_web_channel(self) -> None:
+        class ZapZapBridge(QObject):
+            @pyqtSlot()
+            def on_theme_controller_injection_success(self):
+                self._webview.apply_theme(
+                    ThemeManager.get_current_theme(),
+                    ThemeManager.get_current_color_scheme()
+                )
+
+            @pyqtSlot(str, bool)
+            def on_waweb_theme_changed(self, new_theme_value: str, system_theme_mode: bool):
+                # Redundant protection against theme changes fired from the WhatsApp Web settings.
+                # Force WAWeb to always use the theme from the ZapZap settings.
+                self._webview.apply_theme(
+                    ThemeManager.get_current_theme(),
+                    ThemeManager.get_current_color_scheme()
+                )
+
+            @pyqtSlot(str)
+            def on_theme_controller_failure(self, message: str):
+                if self._webview.whatsapp_page:
+                    self._webview.whatsapp_page.on_apply_theme_result(False, message)
+                    self._webview.whatsapp_page.fall_back_to_force_dark_mode()
+
+            def __init__(self, webview):
+                super().__init__()
+                self.web_channel = QWebChannel(self)
+                self.web_channel.registerObject("zapZapBridge", self)
+                self._webview = webview
+
+        self._web_channel_bridge = ZapZapBridge(self)
+        self.whatsapp_page.setWebChannel(
+            self._web_channel_bridge.web_channel,
+            QWebEngineScript.ScriptWorldId.MainWorld
+        )
+
+    @staticmethod
+    def _get_web_channel_js_code() -> str:
+        file = QFile(":/qtwebchannel/qwebchannel.js")
+        if not file.open(QFile.OpenModeFlag.ReadOnly):
+            raise RuntimeError(file.errorString())
+        return QTextStream(file).readAll()
+
     def configure_spellcheck(self):
         """Configura o corretor ortográfico."""
         if self.user.enable:
@@ -174,9 +253,8 @@ class WebView(QWebEngineView):
         self.whatsapp_page = PageController(self.profile, self)
         self.whatsapp_page.user_id = self.user.id
         self.whatsapp_page.renderProcessTerminated.connect(self._on_render_crash)
-        self.setPage(self.whatsapp_page)
-        self.load(QUrl(__whatsapp_url__))
-        self.setZoomFactor(self.user.zoomFactor)
+        self.load_page()
+        self._inject_web_theme_controller()
 
     def _on_render_crash(self, terminationStatus, exitCode):
         if self._shutting_down or not self.user.enable or not self.whatsapp_page:
@@ -344,15 +422,11 @@ class WebView(QWebEngineView):
         if self.user.enable and self.whatsapp_page:
             self.whatsapp_page.close_conversation()
 
-    def set_theme_light(self):
-        """Define o tema claro na página."""
-        if self.user.enable and self.whatsapp_page:
-            self.whatsapp_page.set_theme_light()
+    def apply_theme(self, current_theme, current_color_scheme) -> None:
+        if self.whatsapp_page is None:
+            return
 
-    def set_theme_dark(self):
-        """Define o tema escuro na página."""
-        if self.user.enable and self.whatsapp_page:
-            self.whatsapp_page.set_theme_dark()
+        self.whatsapp_page.apply_theme(current_theme, current_color_scheme)
 
     def remove_files(self):
         """Remove os arquivos de cache e armazenamento persistente do perfil."""

--- a/zapzap/webengine/theme_controller.js
+++ b/zapzap/webengine/theme_controller.js
@@ -1,0 +1,466 @@
+{qwebchannel_js_code}
+
+(() => {
+    const LOG_PREFIX = "[ZapZap WAWeb Theme Controller]";
+
+    const THEME_CONTEXT_PENDING_TIMEOUT = 60000; // 60 seconds
+
+    const MODULES = {
+        prefs: {
+            name: "WAWebUserPrefsGeneral",      // require("WAWebUserPrefsGeneral")
+            requiredFunctions: [
+                "getTheme",                     // require("WAWebUserPrefsGeneral").getTheme()
+                "setTheme",                     // require("WAWebUserPrefsGeneral").setTheme()
+                "getSystemThemeMode",           // require("WAWebUserPrefsGeneral").getSystemThemeMode()
+                "setSystemThemeMode",           // require("WAWebUserPrefsGeneral").setSystemThemeMode()
+            ],
+        },
+        settingsFBT: {
+            name: "WAWebSettingsFBT",           // require("WAWebSettingsFBT")
+            requiredFunctions: ["themeTitle"],  // require("WAWebSettingsFBT").themeTitle()
+        },
+    };
+
+    const REACT_FIBER_KEYS = [
+        "__reactFiber$",
+        "__reactInternalInstance$",
+        "__reactContainer$",
+    ];
+
+    const ModuleRegistry = {
+        _cache: new Map(),
+
+        get(definition) {
+            if (this._cache.has(definition.name)) {
+                return this._cache.get(definition.name);
+            }
+
+            try {
+                const module = require(definition.name);
+
+                if (
+                    !module ||
+                    !definition.requiredFunctions.every(
+                        (name) => typeof module[name] === "function"
+                    )
+                ) {
+                    return null;
+                }
+
+                this._cache.set(definition.name, module);
+                return module;
+            } catch (_) {
+                return null;
+            }
+        },
+    };
+
+    const ReactHelper = {
+        _fiberKeyFor(element) {
+            if (!element) {
+                return null;
+            }
+
+            return Object.keys(element).find((key) =>
+                REACT_FIBER_KEYS.some((prefix) => key.startsWith(prefix))
+            ) || null;
+        },
+
+        _fiberFromElement(element) {
+            const key = this._fiberKeyFor(element);
+            return key ? element[key] : null;
+        },
+
+        _isThemeContext(value) {
+            return Boolean(
+                value &&
+                typeof value === "object" &&
+                typeof value.setTheme === "function" &&
+                typeof value.setSystemThemeMode === "function"
+            );
+        },
+
+        findThemeContext() {
+            const checkedFibers = new Set();
+
+            for (const element of document.querySelectorAll("*")) {
+                let fiber = this._fiberFromElement(element);
+
+                while (fiber && !checkedFibers.has(fiber)) {
+                    checkedFibers.add(fiber);
+
+                    const props = fiber.memoizedProps || fiber.pendingProps;
+                    const value = props && props.value;
+
+                    if (this._isThemeContext(value)) {
+                        return value;
+                    }
+
+                    fiber = fiber.return;
+                }
+            }
+
+            return null;
+        },
+    };
+
+    const ThemeController = {
+        _failed: false,
+        _is_ready: false,
+        _suppressThemeChangeEvents: false,
+
+        bridge: null,
+        ctx: null,
+        currentColorScheme: "{current_color_scheme}",
+        prefs: null,
+        themeContextObserver: null,
+        themeContextTimeout: null,
+        settingsObserver: null,
+
+        has_failed() {
+            return this._failed;
+        },
+
+        is_ready() {
+            return this._is_ready;
+        },
+
+        applyZapZapColorSchemeToWAWeb() {
+            if (this._failed) {
+                return false;
+            }
+
+            if (!this.ctx) {
+                this._observeThemeContext();
+                return false;
+            }
+
+            const prefs = this._requirePrefs();
+            if (!prefs) {
+                return false;
+            }
+
+            this._changeWAWebThemeWithoutDispatchingThemeChangedEvent(prefs);
+            return !this._failed;
+        },
+
+        boot() {
+            window._zapZapWAWebThemeController = this;
+
+            if (!this._initialize()) {
+                this._observeThemeContext();
+            }
+        },
+
+        _initialize(ctx = null) {
+            if (this._failed) {
+                return false;
+            }
+
+            if (this._is_ready) {
+                return true;
+            }
+
+            this._setupQWebChannel();
+
+            this.ctx = ctx || ReactHelper.findThemeContext();
+            if (!this.ctx) {
+                return false;
+            }
+
+            const prefs = this._requirePrefs();
+            if (!prefs) {
+                return false;
+            }
+
+            this._patchPrefs(prefs);
+            this._removeWAWebThemeSettingsOption();
+            this._stopThemeContextObserver();
+
+            if (!this.applyZapZapColorSchemeToWAWeb()) {
+                return false;
+            }
+
+            this._is_ready = true;
+            console.log(LOG_PREFIX, "WhatsApp Web theme controller initialized.");
+            return true;
+        },
+
+        _requirePrefs() {
+            if (this._failed) {
+                return null;
+            }
+
+            const prefs = ModuleRegistry.get(MODULES.prefs);
+            if (!prefs) {
+                this._fail(
+                    "Unable to control WhatsApp Web theme: WAWebUserPrefsGeneral API changed " +
+                        "or is unavailable."
+                );
+                return null;
+            }
+
+            this.prefs = prefs;
+            return prefs;
+        },
+
+        _setupQWebChannel() {
+            if (
+                this.bridge ||
+                typeof QWebChannel === "undefined" ||
+                typeof qt === "undefined" ||
+                !qt.webChannelTransport
+            ) {
+                return;
+            }
+
+            try {
+                new QWebChannel(qt.webChannelTransport, (channel) => {
+                    this.bridge = channel.objects && channel.objects.zapZapBridge;
+                    this._notifyInjectionSuccess();
+                });
+            } catch (_) {
+                console.warn(
+                    LOG_PREFIX, "QWebChannel failed to initialize. ZapZap may still be " +
+                        "able to change the WhatsApp Web theme, but won't monitor its changes."
+                );
+            }
+        },
+
+        _patchPrefs(prefs) {
+            if (prefs.__zapZapPrefsPatched) {
+                return;
+            }
+
+            prefs.__zapZapOriginalWAWebSetTheme = prefs.setTheme;
+            prefs.__zapZapOriginalWAWebSetSystemThemeMode = prefs.setSystemThemeMode;
+
+            prefs.setTheme = (nextTheme, ...args) => {
+                const previousTheme = prefs.getTheme();
+                const result = prefs.__zapZapOriginalWAWebSetTheme.call(prefs, nextTheme, ...args);
+                const currentTheme = prefs.getTheme();
+
+                if (!this._suppressThemeChangeEvents && currentTheme !== previousTheme) {
+                    this._notifyWAWebThemeChanged(
+                        previousTheme,
+                        currentTheme,
+                        prefs.getSystemThemeMode()
+                    );
+                }
+
+                return result;
+            };
+
+            prefs.setSystemThemeMode = (nextSystemThemeMode, ...args) => {
+                const previousSystemThemeMode = prefs.getSystemThemeMode();
+                const result = prefs.__zapZapOriginalWAWebSetSystemThemeMode.call(
+                    prefs,
+                    nextSystemThemeMode,
+                    ...args
+                );
+
+                if (
+                    !this._suppressThemeChangeEvents &&
+                    previousSystemThemeMode !== nextSystemThemeMode
+                ) {
+                    const currentTheme = prefs.getTheme();
+                    this._notifyWAWebThemeChanged(
+                        currentTheme,
+                        currentTheme,
+                        nextSystemThemeMode
+                    );
+                }
+
+                return result;
+            };
+
+            prefs.__zapZapPrefsPatched = true;
+        },
+
+        _unpatchPrefs() {
+            const prefs = this.prefs || ModuleRegistry.get(MODULES.prefs);
+            if (!prefs || !prefs.__zapZapPrefsPatched) {
+                return;
+            }
+
+            if (typeof prefs.__zapZapOriginalWAWebSetTheme === "function") {
+                prefs.setTheme = prefs.__zapZapOriginalWAWebSetTheme;
+            }
+
+            if (typeof prefs.__zapZapOriginalWAWebSetSystemThemeMode === "function") {
+                prefs.setSystemThemeMode = prefs.__zapZapOriginalWAWebSetSystemThemeMode;
+            }
+
+            delete prefs.__zapZapOriginalWAWebSetTheme;
+            delete prefs.__zapZapOriginalWAWebSetSystemThemeMode;
+            delete prefs.__zapZapPrefsPatched;
+        },
+
+        _changeWAWebThemeWithoutDispatchingThemeChangedEvent(prefs) {
+            this._suppressThemeChangeEvents = true;
+
+            try {
+                // QWebEngine currently does not propagate system theme changes reliably
+                // to the embedded page, so ZapZap keeps WAWeb out of system-theme mode
+                // and applies the effective theme manually.
+                if (prefs.getSystemThemeMode()) {
+                    this.ctx.setSystemThemeMode(false);
+                }
+
+                if (prefs.getTheme() !== this.currentColorScheme) {
+                    this.ctx.setTheme(this.currentColorScheme);
+                }
+            } catch (_) {
+                this._fail("Unable to apply WhatsApp Web theme: ThemeContext API changed or is unavailable.");
+            } finally {
+                this._suppressThemeChangeEvents = false;
+            }
+        },
+
+        _removeWAWebThemeSettingsOption() {
+            const settingsFBT = ModuleRegistry.get(MODULES.settingsFBT);
+            if (!settingsFBT || !document.body) {
+                console.warn(
+                    LOG_PREFIX, "Unable to hide the WhatsApp Web theme settings option."
+                );
+                return;
+            }
+
+            let selector;
+            try {
+                const title = String(settingsFBT.themeTitle());
+                const escaped_title = window.CSS?.escape ? CSS.escape(title) : title.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+                selector = `[aria-label="${escaped_title}"]`;
+            } catch (_) {
+                console.warn(
+                    LOG_PREFIX, "Unable to hide the WhatsApp Web theme settings option."
+                );
+                return;
+            }
+
+            const removeItem = () => {
+                const item = document.querySelector(selector);
+                if (item) {
+                    item.remove();
+                }
+            };
+
+            removeItem();
+
+            if (this.settingsObserver) {
+                this.settingsObserver.disconnect();
+            }
+
+            let scheduled = false;
+            this.settingsObserver = new MutationObserver(() => {
+                if (scheduled) {
+                    return;
+                }
+
+                scheduled = true;
+                requestAnimationFrame(() => {
+                    scheduled = false;
+                    removeItem();
+                });
+            });
+
+            this.settingsObserver.observe(document.body, {
+                childList: true,
+                subtree: true,
+            });
+        },
+
+        _observeThemeContext() {
+            if (this._failed || this.themeContextObserver) {
+                return;
+            }
+
+            this.themeContextObserver = new MutationObserver(() => {
+                const ctx = ReactHelper.findThemeContext();
+                if (ctx) {
+                    this._initialize(ctx);
+                }
+            });
+
+            this.themeContextObserver.observe(document.documentElement, {
+                childList: true,
+                subtree: true,
+            });
+
+            this.themeContextTimeout = setTimeout(() => {
+                if (!this._is_ready && !this._failed) {
+                    this._fail(
+                        `Unable to find WhatsApp Web ThemeContext after ${THEME_CONTEXT_PENDING_TIMEOUT} milliseconds.`
+                    );
+                }
+            }, THEME_CONTEXT_PENDING_TIMEOUT);
+        },
+
+        _stopThemeContextObserver() {
+            if (this.themeContextObserver) {
+                this.themeContextObserver.disconnect();
+                this.themeContextObserver = null;
+            }
+
+            if (this.themeContextTimeout) {
+                clearTimeout(this.themeContextTimeout);
+                this.themeContextTimeout = null;
+            }
+        },
+
+        _stopSettingsObserver() {
+            if (!this.settingsObserver) {
+                return;
+            }
+
+            this.settingsObserver.disconnect();
+            this.settingsObserver = null;
+        },
+
+        _notifyWAWebThemeChanged(oldTheme, newTheme, systemThemeMode) {
+            if (
+                this._failed ||
+                !this.bridge ||
+                typeof this.bridge.on_waweb_theme_changed !== "function"
+            ) {
+                return;
+            }
+
+            this.bridge.on_waweb_theme_changed(newTheme, systemThemeMode);
+        },
+
+        _notifyInjectionSuccess() {
+            if (
+                this._failed ||
+                !this.bridge ||
+                typeof this.bridge.on_theme_controller_injection_success !== "function"
+            ) {
+                return;
+            }
+
+            this.bridge.on_theme_controller_injection_success();
+        },
+
+        _fail(message) {
+            // The entire code must be exception-proof, with all caught failures funneling
+            // into this function to allow the theme controller to properly signal ZapZap
+            // that it must activate the fallback color scheme control via ForceDarkMode.
+            if (this._failed) {
+                return;
+            }
+
+            this._failed = true;
+            console.error(LOG_PREFIX, message);
+
+            if (this.bridge && typeof this.bridge.on_theme_controller_failure === "function") {
+                this.bridge.on_theme_controller_failure(message);
+            }
+
+            this._stopThemeContextObserver();
+            this._stopSettingsObserver();
+            this._unpatchPrefs();
+        },
+    };
+
+    ThemeController.boot();
+})();


### PR DESCRIPTION
This PR fixes #436, #662, #666, #667 and #698 by refactoring the ThemeManager class and the WhatsApp Web theme sync logic.

Most relevant changes include controlling the WhatsApp Web Theme via react/javascript (with a safety fallback to ForceDarkMode in case of WAWeb API changes) and no more polling for system theme changes with a QTimer (now changes are monitored via xdg-desktop-portal with a fallback to Qt style hints)

Tested both standalone and Flatpak versions on KDE Plasma, GNOME and Cinnamon on Arch Linux [Wayland], Fedora 44 [Wayland and X11] and Debian 13 [Wayland and X11]. Also tested on Windows.