### PR TITLE
Feature: add browser-level queue for WhatsApp Web page load requests

### DIFF
--- a/zapzap/controllers/Browser.py
+++ b/zapzap/controllers/Browser.py
@@ -1,4 +1,7 @@
-from PyQt6.QtCore import QEasingCurve, QParallelAnimationGroup, QPropertyAnimation, Qt
+import random
+import time
+
+from PyQt6.QtCore import QEasingCurve, QParallelAnimationGroup, QPropertyAnimation, Qt, QTimer
 from PyQt6.QtWidgets import QWidget, QPushButton, QMessageBox
 from PyQt6.QtGui import QAction
 from zapzap.controllers.CardUser import CardUser
@@ -33,6 +36,16 @@ class Browser(QWidget, Ui_Browser):
         self._sidebar_animation_group = None
         self._last_active_webview = None
         self._shutting_down = False
+        self._page_load_queue: list[tuple[int, WebView]] = []
+        self._queued_page_loads: set[WebView] = set()
+        self._next_allowed_page_load_ms = 0
+
+        self._page_load_timer = QTimer(self)
+        self._page_load_timer.setSingleShot(True)
+        self._page_load_timer.timeout.connect(self._process_page_load_queue)
+
+        self._page_load_interval_min_ms = 1000
+        self._page_load_interval_max_ms = 2000
 
         self._initialize()
 
@@ -154,7 +167,7 @@ class Browser(QWidget, Ui_Browser):
         page_index = self.page_count
 
         # Criar uma nova página
-        new_page = WebView(user, page_index)
+        new_page = WebView(self, user, page_index)
         new_page.update_button_signal.connect(
             self.update_page_button_number_notifications
         )
@@ -192,6 +205,7 @@ class Browser(QWidget, Ui_Browser):
         button, page = self._find_button_and_page_by_user(user)
 
         if page:
+            self.cancel_queued_page_load(page)
             self.pages.removeWidget(page)
             page.shutdown()
             page.remove_files()
@@ -313,6 +327,8 @@ class Browser(QWidget, Ui_Browser):
 
     def close_pages(self):
         """Fecha e limpa todas as páginas existentes."""
+        self._clear_page_load_queue()
+
         for i in reversed(range(self.pages.count())):
             page = self.pages.widget(i)
 
@@ -333,9 +349,13 @@ class Browser(QWidget, Ui_Browser):
     def reload_pages(self):
         """Recarrega todas as páginas existentes."""
         for i in range(self.pages.count()):
-            if i == self.grid_page_index: continue
+            if i == self.grid_page_index:
+                continue
+
             page = self.pages.widget(i)
-            page.load_page()
+
+            if isinstance(page, WebView):
+                self.queue_load_page(page)
 
     def close_conversations(self):
         """Fecha todas as conversas abertas."""
@@ -562,3 +582,88 @@ class Browser(QWidget, Ui_Browser):
         group.finished.connect(_on_finished)
         self._sidebar_animation_group = group
         group.start()
+
+    def queue_load_page(self, page: WebView, delay_ms: int = 0) -> None:
+        if self._shutting_down:
+            return
+
+        if page is None or page.whatsapp_page is None:
+            return
+
+        if page in self._queued_page_loads:
+            return
+
+        run_at_ms = self._now_ms() + max(0, delay_ms)
+
+        self._page_load_queue.append((run_at_ms, page))
+        self._queued_page_loads.add(page)
+        self._page_load_queue.sort(key=lambda item: item[0])
+
+        self._schedule_next_page_load()
+
+    def cancel_queued_page_load(self, page: WebView) -> None:
+        if page not in self._queued_page_loads:
+            return
+
+        self._page_load_queue = [
+            item for item in self._page_load_queue
+            if item[1] is not page
+        ]
+        self._queued_page_loads.discard(page)
+
+        self._schedule_next_page_load()
+
+    def _process_page_load_queue(self) -> None:
+        if self._shutting_down:
+            return
+
+        if not self._page_load_queue:
+            self._page_load_timer.stop()
+            return
+
+        now_ms = self._now_ms()
+        run_at_ms, page = self._page_load_queue[0]
+
+        if now_ms < run_at_ms or now_ms < self._next_allowed_page_load_ms:
+            self._schedule_next_page_load()
+            return
+
+        self._page_load_queue.pop(0)
+        self._queued_page_loads.discard(page)
+
+        if page is not None and page.whatsapp_page is not None:
+            page.load_page_now()
+
+        interval_ms = random.randint(
+            self._page_load_interval_min_ms,
+            self._page_load_interval_max_ms,
+        )
+        self._next_allowed_page_load_ms = self._now_ms() + interval_ms
+
+        self._schedule_next_page_load()
+
+    def _schedule_next_page_load(self) -> None:
+        if self._shutting_down:
+            return
+
+        if not self._page_load_queue:
+            self._page_load_timer.stop()
+            return
+
+        now_ms = self._now_ms()
+        run_at_ms, _page = self._page_load_queue[0]
+
+        next_run_ms = max(run_at_ms, self._next_allowed_page_load_ms)
+        delay_ms = max(0, next_run_ms - now_ms)
+
+        self._page_load_timer.start(delay_ms)
+
+    def _clear_page_load_queue(self) -> None:
+        self._page_load_timer.stop()
+        self._page_load_queue.clear()
+        self._queued_page_loads.clear()
+        self._next_allowed_page_load_ms = 0
+
+    @staticmethod
+    def _now_ms() -> int:
+        return time.monotonic_ns() // 1_000_000

--- a/zapzap/controllers/PageCustomizations.py
+++ b/zapzap/controllers/PageCustomizations.py
@@ -740,7 +740,7 @@ class PageCustomizations(QWidget, Ui_PageCustomizations):
         if not target_webview:
             return False
 
-        target_webview.load_page()
+        target_webview.schedule_load_page()
         if not silent:
             self._show_feedback(_("Reload complete."))
 

--- a/zapzap/webengine/PageController.py
+++ b/zapzap/webengine/PageController.py
@@ -174,7 +174,7 @@ class PageController(QWebEnginePage):
         )
         # Reload WhatsApp Web page to force it to load the theme settings saved
         # in localStorage.
-        cast(WebView, cast(object, self.parent())).load_page()
+        cast(WebView, cast(object, self.parent())).schedule_load_page()
 
     def new_chat(self):
         """Simula o atalho 'Ctrl+Alt+N' para iniciar um novo chat."""

--- a/zapzap/webengine/WebView.py
+++ b/zapzap/webengine/WebView.py
@@ -1,17 +1,23 @@
+from __future__ import annotations
+
 import re
 import shutil
 import os
 
+from typing import TYPE_CHECKING
+
 from PyQt6.QtWebChannel import QWebChannel
 from PyQt6.QtWebEngineWidgets import QWebEngineView
 from PyQt6.QtWebEngineCore import QWebEngineProfile, QWebEngineSettings, QWebEnginePage, QWebEngineScript
-from PyQt6.QtCore import QUrl, pyqtSignal, QTimer, QEvent, Qt, QFile, QTextStream, QObject, pyqtSlot
+from PyQt6.QtCore import QUrl, pyqtSignal, QEvent, Qt, QFile, QTextStream, QObject, pyqtSlot
 from PyQt6.QtWidgets import QApplication, QWidget
 from PyQt6.QtGui import QAction
 
+if TYPE_CHECKING:
+    from zapzap.controllers.Browser import Browser
 from zapzap.services.ThemeManager import ThemeManager
 from zapzap.webengine.PageController import PageController
-from zapzap.models import User
+from zapzap.models.User import User
 from zapzap import __user_agent__, __whatsapp_url__
 from zapzap.notifications.NotificationService import NotificationService
 from zapzap.services.DictionariesManager import DictionariesManager
@@ -42,35 +48,23 @@ class WebView(QWebEngineView):
         "Linux Chrome": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
     }
 
-    def __init__(self, user: User = None, page_index=None, parent=None):
+    def __init__(self, browser: Browser, user: User = None, page_index=None, parent=None):
         super().__init__(parent)
         self.user = user
         self.page_index = page_index
         self.profile = None  # Inicializa o perfil como None
         self._gesture_filter_installed = False
         self.whatsapp_page = None
-
         self._cache_path = None
         self._storage_path = None
-
         self.notifications = NotificationService()
         self._devtools_view = None
         self._devtools_page = None
-
         self._last_tmp_file = None
         self._shutting_down = False
-
         self._web_channel_bridge = None
-
-        self._reload_timer = QTimer(self)
-        self._reload_timer.setSingleShot(True)
-        self._reload_timer.timeout.connect(self.load_page)
-
-        self._render_crash_reload_timer = QTimer(self)
-        self._render_crash_reload_timer.setSingleShot(True)
-        self._render_crash_reload_timer.timeout.connect(self.load_page)
-
         self._signals_configured = False
+        self._browser = browser
 
         if user.enable:
             self._initialize()
@@ -253,14 +247,15 @@ class WebView(QWebEngineView):
         self.whatsapp_page = PageController(self.profile, self)
         self.whatsapp_page.user_id = self.user.id
         self.whatsapp_page.renderProcessTerminated.connect(self._on_render_crash)
-        self.load_page()
+        self.setPage(self.whatsapp_page)
         self._inject_web_theme_controller()
+        self.schedule_load_page()
 
     def _on_render_crash(self, terminationStatus, exitCode):
         if self._shutting_down or not self.user.enable or not self.whatsapp_page:
             return
         print(f"Tab renderer crashed (status={terminationStatus}, code={exitCode}). Reloading...")
-        self._render_crash_reload_timer.start(1000)
+        self.schedule_load_page(delay_ms=1000)
 
     def contextMenuEvent(self, event):
         """Cria o menu de contexto personalizado ao clicar com o botão direito."""
@@ -352,13 +347,13 @@ class WebView(QWebEngineView):
         """Ativa/desativa a correção ortográfica."""
         print("Correção ortográfica:", toggled)
         SettingsManager.set("system/spellCheckers", toggled)
-        QApplication.instance().getWindow().browser.update_spellcheck()
+        self._browser.update_spellcheck()
 
     def _select_language(self, lang):
         """Seleciona o idioma para correção ortográfica."""
         print("Linguagem selecionada via menu de contexto:", lang)
         DictionariesManager.set_lang(lang)
-        QApplication.instance().getWindow().browser.update_spellcheck()
+        self._browser.update_spellcheck()
 
     def _on_title_changed(self, title):
         """Manipula mudanças no título da página."""
@@ -371,7 +366,7 @@ class WebView(QWebEngineView):
             return
         if not success:
             print("You are not connected to the Internet.")
-            self._reload_timer.start(5000)
+            self.schedule_load_page(delay_ms=5000)
 
     def event(self, event):
         """Intercept native gesture events to optionally disable pinch-to-zoom.
@@ -403,15 +398,21 @@ class WebView(QWebEngineView):
         new_zoom = 1.0 if factor is None else self.zoomFactor() + factor
         self.setZoomFactor(new_zoom)
 
-    def load_page(self):
-        """Carrega a página do WhatsApp."""
+    def load_page_now(self) -> None:
+        """Loads WhatsApp Web page immediately."""
         if self._shutting_down:
             return
 
         if self.user.enable and self.whatsapp_page:
-            self.setPage(self.whatsapp_page)
             self.load(QUrl(__whatsapp_url__))
             self.setZoomFactor(self.user.zoomFactor)
+
+    def schedule_load_page(self, delay_ms: int = 0) -> None:
+        """Request the Browser to schedule the loading of the WhatsApp Web page."""
+        if self._shutting_down:
+            return
+
+        self._browser.queue_load_page(self, delay_ms)
 
     def apply_custom_css(self):
         if self.user.enable and self.whatsapp_page:
@@ -467,17 +468,8 @@ class WebView(QWebEngineView):
         self._shutting_down = True
         self._teardown_webengine(clear_cache=False)
 
-    def _stop_timers(self):
-        for timer in (
-                getattr(self, "_reload_timer", None),
-                getattr(self, "_render_crash_reload_timer", None),
-        ):
-            if timer:
-                timer.stop()
-
     def _teardown_webengine(self, clear_cache: bool=False):
         """Destrói objetos Qt associados à WebEngine de forma ordenada."""
-        self._stop_timers()
         self._save_zoom_factor()
         self.stop()
 


### PR DESCRIPTION
When multiple accounts are enabled, ZapZap starts several WhatsApp Web sessions at nearly the same time, creating a burst of page loads and network requests during startup. This could potentially trigger rate limiting or anti-abuse heuristics on WhatsApp's server side.

That was my main suspicion as the root cause of #693, but sadly we could not get more information from the issue reporter.

Anyhow, this change improves ZapZap's reliability by introducing a Browser-level page load queue. Startup load requests are now processed one by one, with a randomized interval of 1 to 2 seconds between each effective load, reducing the request spike during startup.