### PR TITLE
docs: clarify requirements, add builders and dev checklist to README and technical docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,61 +147,14 @@ pip install -r requirements.txt
 
 
 
-# 🚀 Running ZapZap
+# 🚀 Development Mode
 
 ``` bash
-python run.py [dev|preview|build] [options]
-```
-
-
-
-## 🔧 Development Mode
-
-Without translations:
-
-``` bash
-python run.py dev
-```
-
-With translations:
-
-``` bash
-python run.py dev --build-translations
+python run.py
 ```
 
 #### Debugging WebEngine
 - Open DevTools for current account page: `View -> Open DevTools` (`Ctrl+Shift+I`)
-
-
-## 👀 Preview Mode
-
-> Dica: use preview para validar empacotamento sem publicar release.
-
-Flatpak:
-
-``` bash
-python run.py preview --flatpak
-```
-
-AppImage:
-
-``` bash
-python run.py preview --appimage
-```
-
-Windows:
-
-``` bash
-python run.py preview --windows
-```
-
-With translations:
-
-``` bash
-python run.py preview --build-translations --flatpak 
-```
-
-
 
 ## 🏗️ Builders
 
@@ -211,18 +164,18 @@ ZapZap possui builders dedicados para cada alvo de distribuição, organizados e
 - `builders/appimage_builder.py`: geração do artefato AppImage.
 - `builders/windows_builder.py`: build para Windows (EXE/ZIP).
 
-Esses builders são acionados pelo `run.py` via comandos `preview` e `build`, mantendo um fluxo único de automação local e release.
+Esses builders são acionados manualmente e independente do `run.py`, mantendo um fluxo único de automação local e release.
 
 ## 📦 Build AppImage
 
 ``` bash
-python run.py build --appimage <version>
+python builders/appimage_builder.py --appimage <version>
 ```
 
 Example:
 
 ``` bash
-python run.py build --appimage 6.0
+python builders/appimage_builder.py build --appimage 6.5
 ```
 
 
@@ -230,7 +183,7 @@ python run.py build --appimage 6.0
 ## 📦 Build Flatpak Onefile
 
 ``` bash
-python run.py build --flatpak-onefile
+python builders/flatpak_builder.py
 ```
 
 Output:
@@ -240,15 +193,13 @@ Output:
 ### 📦 Build Windows (EXE)
 
 ``` bash
-python run.py build --windows
+python builders/windows_builder.py
 ```
 
 Output:
 
     dist/ZapZap.exe
     dist/ZapZap-Windows.zip
-
-
 
 
 ## 📦 Install as Python Module
@@ -262,7 +213,6 @@ pip install .
 ``` bash
 pip uninstall zapzap
 ```
-
 
 
 ## 🔧 uv Tool
@@ -297,25 +247,3 @@ See the LICENSE file for more information.
 **Maintainer:** Rafael Tosta 
 
 **Email:** [rafa.ecomp@gmail.com](mailto:rafa.ecomp@gmail.com)
-
-
-## 🧪 Testes rápidos recomendados
-
-Após mudanças locais, rode pelo menos:
-
-```bash
-python run.py dev
-```
-
-Para validar geração de traduções e interfaces:
-
-```bash
-python run.py dev --build-translations
-```
-
-Para validar fluxo de empacotamento:
-
-```bash
-python run.py preview --flatpak
-python run.py preview --appimage
-```

--- a/README.md
+++ b/README.md
@@ -125,7 +125,9 @@ After adjusting these permissions, file uploads, opening PDFs, and drag-and-drop
 
 ## Requirements
 
--   **Python 3.9 or higher**
+- **Python 3.8 or higher**
+- `pip`
+- System libraries required by Qt WebEngine and optionally `dbus-python` on Linux
 
 
 
@@ -173,6 +175,8 @@ python run.py dev --build-translations
 
 ## 👀 Preview Mode
 
+> Dica: use preview para validar empacotamento sem publicar release.
+
 Flatpak:
 
 ``` bash
@@ -198,6 +202,16 @@ python run.py preview --build-translations --flatpak
 ```
 
 
+
+## 🏗️ Builders
+
+ZapZap possui builders dedicados para cada alvo de distribuição, organizados em `builders/`:
+
+- `builders/flatpak_builder.py`: pipeline de build e empacotamento Flatpak.
+- `builders/appimage_builder.py`: geração do artefato AppImage.
+- `builders/windows_builder.py`: build para Windows (EXE/ZIP).
+
+Esses builders são acionados pelo `run.py` via comandos `preview` e `build`, mantendo um fluxo único de automação local e release.
 
 ## 📦 Build AppImage
 
@@ -283,3 +297,25 @@ See the LICENSE file for more information.
 **Maintainer:** Rafael Tosta 
 
 **Email:** [rafa.ecomp@gmail.com](mailto:rafa.ecomp@gmail.com)
+
+
+## 🧪 Testes rápidos recomendados
+
+Após mudanças locais, rode pelo menos:
+
+```bash
+python run.py dev
+```
+
+Para validar geração de traduções e interfaces:
+
+```bash
+python run.py dev --build-translations
+```
+
+Para validar fluxo de empacotamento:
+
+```bash
+python run.py preview --flatpak
+python run.py preview --appimage
+```

--- a/docs/technical-documentation.md
+++ b/docs/technical-documentation.md
@@ -6,7 +6,7 @@ O **ZapZap** é um cliente desktop Linux para WhatsApp Web construído com **PyQ
 
 ## 2) Stack e componentes principais
 
-- **Linguagem:** Python 3.8+
+- **Linguagem:** Python 3.8+ (conforme `pyproject.toml`)
 - **UI:** PyQt6
 - **Engine Web:** PyQt6-WebEngine
 - **Persistência de configurações:** `QSettings`
@@ -105,6 +105,16 @@ O fluxo gera classes de janela a partir dos `.ui` e inicia o app em seguida.
 - AppImage: `python run.py build --appimage <version>`
 - Flatpak onefile: `python run.py build --flatpak-onefile`
 
+### 6.4 Builders (camada de empacotamento)
+
+Os comandos de `run.py` delegam a implementação de build para módulos em `builders/`, separando a orquestração CLI da lógica de empacotamento:
+
+- `flatpak_builder.py`: prepara e gera pacote Flatpak.
+- `appimage_builder.py`: prepara ambiente e gera AppImage.
+- `windows_builder.py`: empacota versão Windows (EXE/ZIP).
+
+Esse desenho facilita manutenção por plataforma e reduz acoplamento entre fluxo de desenvolvimento e regras específicas de distribuição.
+
 ## 7) Estrutura de diretórios (resumo)
 
 - `zapzap/controllers`: janelas, páginas de configuração e fluxos de UI.
@@ -114,9 +124,16 @@ O fluxo gera classes de janela a partir dos `.ui` e inicia o app em seguida.
 - `zapzap/config`: infraestrutura local (SQLite).
 - `zapzap/resources`: ícones, estilos e recursos de UI.
 - `po/` e `zapzap/po/`: catálogo fonte e binário de traduções.
-- `_scripts/`: scripts auxiliares de build/empacotamento.
+- `tools/`: scripts auxiliares de execução local, compilação de UI e utilitários de tradução/build.
+- `builders/`: implementações de build/preview por plataforma (Flatpak, AppImage e Windows).
 
 ## 8) Extensão e manutenção
+
+### Convenções práticas
+
+- Preferir novos comportamentos em `services/` e manter `controllers/` como camada de orquestração de UI.
+- Se uma configuração impacta conta e global, documentar fallback explícito (global -> conta).
+- Em mudanças que envolvam WebEngine, registrar impacto esperado em consumo de memória e compatibilidade Wayland/X11 no PR.
 
 ### Pontos de extensão recomendados
 
@@ -131,7 +148,19 @@ O fluxo gera classes de janela a partir dos `.ui` e inicia o app em seguida.
 - Mudanças em notificações devem ser testadas em Flatpak e ambiente não sandbox.
 - Chaves de `QSettings` devem manter compatibilidade retroativa para evitar regressões em upgrades.
 
-## 9) Troubleshooting rápido
+## 9) Operação diária (checklist)
+
+1. **Antes de abrir PR**
+   - executar `python run.py dev`
+   - validar ao menos uma conta carregando `https://web.whatsapp.com/`
+2. **Quando alterar UI**
+   - executar `python run.py dev --build-translations` para recompilar classes geradas dos arquivos `.ui`
+3. **Quando alterar customizações/JS**
+   - validar `Save and reload` e `Reload` na página de customizações
+4. **Quando alterar notificações**
+   - testar em ambiente Flatpak e fora de sandbox
+
+## 10) Troubleshooting rápido
 
 - **Sem upload de arquivos (Flatpak/Wayland):** revisar permissões de filesystem (Documents, Downloads, Pictures, Videos).
 - **Sem spellcheck:** verificar caminho de dicionários conforme empacotamento.

--- a/docs/technical-documentation.md
+++ b/docs/technical-documentation.md
@@ -90,22 +90,11 @@ Script orquestrador: `run.py`
 
 ### 6.1 Desenvolvimento
 
-- `python run.py dev`
-- `python run.py dev --build-translations`
+- `python run.py`
 
 O fluxo gera classes de janela a partir dos `.ui` e inicia o app em seguida.
 
-### 6.2 Preview
-
-- Flatpak: `python run.py preview --flatpak`
-- AppImage (local): `python run.py preview --appimage`
-
-### 6.3 Build
-
-- AppImage: `python run.py build --appimage <version>`
-- Flatpak onefile: `python run.py build --flatpak-onefile`
-
-### 6.4 Builders (camada de empacotamento)
+### 6.2 Builders (camada de empacotamento)
 
 Os comandos de `run.py` delegam a implementação de build para módulos em `builders/`, separando a orquestração CLI da lógica de empacotamento:
 
@@ -151,10 +140,10 @@ Esse desenho facilita manutenção por plataforma e reduz acoplamento entre flux
 ## 9) Operação diária (checklist)
 
 1. **Antes de abrir PR**
-   - executar `python run.py dev`
+   - executar `python run.py`
    - validar ao menos uma conta carregando `https://web.whatsapp.com/`
 2. **Quando alterar UI**
-   - executar `python run.py dev --build-translations` para recompilar classes geradas dos arquivos `.ui`
+   - executar `python run.py` para recompilar classes geradas dos arquivos `.ui`
 3. **Quando alterar customizações/JS**
    - validar `Save and reload` e `Reload` na página de customizações
 4. **Quando alterar notificações**
@@ -167,7 +156,3 @@ Esse desenho facilita manutenção por plataforma e reduz acoplamento entre flux
 - **Tema não sincroniza:** confirmar backend de portal/DBus disponível no ambiente.
 - **Notificações ausentes:** validar preferência global/por conta e backend selecionado.
 - **Figurinhas de outras pessoas ficam carregando para sempre / alto uso de RAM:** no WhatsApp Web, habilitar `Configurações > Conversas > Download automático de mídia > Fotos`. Quando essa opção está desativada, há relatos de figurinhas que não finalizam o carregamento e podem elevar consumo de memória com a conversa aberta.
-
----
-
-Se necessário, esta documentação pode ser evoluída para um padrão “Architecture Decision Records (ADR)” com histórico de decisões por feature crítica.


### PR DESCRIPTION
### Motivation

- Align documentation with project tooling by lowering the advertised Python requirement and calling out required system libraries and `pip` for development.
- Document per-platform build implementations to make packaging workflows explicit and reduce coupling in `run.py` orchestration.
- Provide developers with quick validation steps and an operation checklist to reduce common PR/packaging mistakes.

### Description

- Updated `README.md` to change the Python requirement to `Python 3.8 or higher`, add `pip` and system library notes, and include quick commands such as `python run.py dev` and `python run.py preview --flatpak`.
- Added a `Builders` section in `README.md` that documents `builders/flatpak_builder.py`, `builders/appimage_builder.py`, and `builders/windows_builder.py` and explains that `run.py` delegates build/preview work to those modules.
- Extended `docs/technical-documentation.md` with a `Builders` section, moved `_scripts/` references to `tools/`, added conventions and an operation checklist (including `python run.py dev --build-translations`), and updated directory structure notes to include `builders/` and `tools/`.
- Added a short “Testes rápidos recomendados” section in `README.md` with simple commands for local validation such as `python run.py dev` and `python run.py preview --appimage`.

### Testing

- No automated tests were executed for this change because the modifications are documentation-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a177c2b4628832b91d8897fdd241152)