### PR TITLE
Fix image download filenames

### DIFF
--- a/zapzap/controllers/DownloadDialog.py
+++ b/zapzap/controllers/DownloadDialog.py
@@ -17,6 +17,7 @@ from gettext import gettext as _
 import os
 
 from zapzap.services.SettingsManager import SettingsManager
+from zapzap.services.DownloadNamingService import DownloadNamingService
 
 
 class DownloadDialog(QDialog):
@@ -268,23 +269,31 @@ class DownloadDialog(QDialog):
             else QFileDialog.Option(0)
         )
 
+        name_filter = f"*.{suffix}" if suffix else "*"
+
         path, __ = QFileDialog.getSaveFileName(
             self,
             _("Save file"),
             os.path.join(directory, file_name),
-            f"*.{suffix}",
+            name_filter,
             options=options
         )
 
         if not path:
             return
 
+        normalized_file_name = DownloadNamingService.normalized_file_name(
+            os.path.basename(path),
+            self.download.mimeType(),
+            self.download.url().toString()
+        )
+
         self.download.setDownloadDirectory(
             os.path.dirname(path)
         )
 
         self.download.setDownloadFileName(
-            os.path.basename(path)
+            normalized_file_name
         )
 
         self.download.accept()

--- a/zapzap/services/DownloadManager.py
+++ b/zapzap/services/DownloadManager.py
@@ -1,6 +1,7 @@
 from PyQt6.QtWebEngineCore import QWebEngineDownloadRequest
 from PyQt6.QtCore import QStandardPaths
 from zapzap.services.SettingsManager import SettingsManager
+from zapzap.services.DownloadNamingService import DownloadNamingService
 from PyQt6.QtWidgets import QFileDialog
 
 from zapzap.controllers.DownloadDialog import DownloadDialog
@@ -47,8 +48,21 @@ class DownloadManager:
             DownloadManager.get_path()
         )
 
+        DownloadManager._normalize_download_file_name(download)
+
         dialog = DownloadDialog(download, parent)
         dialog.show()
+
+    @staticmethod
+    def _normalize_download_file_name(download: QWebEngineDownloadRequest):
+        file_name = DownloadNamingService.normalized_file_name(
+            download.downloadFileName() or download.suggestedFileName(),
+            download.mimeType(),
+            download.url().toString()
+        )
+
+        if file_name != download.downloadFileName():
+            download.setDownloadFileName(file_name)
 
     @staticmethod
     def open_folder_dialog(parent):

--- a/zapzap/services/DownloadNamingService.py
+++ b/zapzap/services/DownloadNamingService.py
@@ -1,0 +1,81 @@
+import os
+from urllib.parse import unquote
+
+
+class DownloadNamingService:
+    IMAGE_MIME_EXTENSIONS = {
+        "image/jpeg": ".jpeg",
+        "image/jpg": ".jpeg",
+        "image/png": ".png",
+        "image/gif": ".gif",
+        "image/webp": ".webp",
+        "image/bmp": ".bmp",
+        "image/svg+xml": ".svg",
+        "image/tiff": ".tiff",
+        "image/x-icon": ".ico",
+        "image/vnd.microsoft.icon": ".ico",
+    }
+
+    @staticmethod
+    def normalized_file_name(
+        file_name: str,
+        mime_type: str = "",
+        url: str = ""
+    ) -> str:
+        file_name = DownloadNamingService._fallback_file_name(
+            file_name,
+            mime_type,
+            url
+        )
+
+        if DownloadNamingService._has_extension(file_name):
+            return file_name
+
+        extension = DownloadNamingService.extension_for_mime_type(mime_type)
+        if not extension:
+            return file_name
+
+        file_name = DownloadNamingService._visible_file_name(file_name)
+        return f"{file_name}{extension}"
+
+    @staticmethod
+    def extension_for_mime_type(mime_type: str) -> str:
+        normalized_mime_type = (
+            mime_type or ""
+        ).split(";", 1)[0].strip().lower()
+
+        return DownloadNamingService.IMAGE_MIME_EXTENSIONS.get(
+            normalized_mime_type,
+            ""
+        )
+
+    @staticmethod
+    def _fallback_file_name(file_name: str, mime_type: str, url: str) -> str:
+        file_name = (file_name or "").strip()
+        if file_name:
+            return file_name
+
+        url_file_name = DownloadNamingService._file_name_from_url(url)
+        if url_file_name:
+            return url_file_name
+
+        if DownloadNamingService.extension_for_mime_type(mime_type):
+            return "image"
+
+        return "download"
+
+    @staticmethod
+    def _file_name_from_url(url: str) -> str:
+        path = (url or "").split("?", 1)[0].split("#", 1)[0]
+        path = path.rstrip("/")
+        file_name = os.path.basename(unquote(path))
+        return file_name.strip()
+
+    @staticmethod
+    def _visible_file_name(file_name: str) -> str:
+        return file_name.lstrip(".") or "image"
+
+    @staticmethod
+    def _has_extension(file_name: str) -> bool:
+        root, extension = os.path.splitext(file_name)
+        return bool(root and extension)


### PR DESCRIPTION
### Motivation
- Image downloads without an explicit extension were being saved with no or incorrect filenames when the `QWebEngineDownloadRequest` provided a MIME type but no extension.  
- Provide predictable filenames for images (JPEGs in particular) and reuse the same normalization when users pick `Save as`.

### Description
- Add `zapzap/services/DownloadNamingService.py` to map common image MIME types to extensions and to compute a normalized fallback filename from the download filename, URL or MIME type.  
- Integrate normalization into `DownloadManager.on_downloadRequested` by calling `DownloadManager._normalize_download_file_name(...)` before showing the download dialog.  
- Update `DownloadDialog._save_as` to apply `DownloadNamingService.normalized_file_name(...)` when the user selects a path, and make the file picker filter robust when the suffix is empty.  
- Handle hidden/extensionless names by stripping a leading `.` and using URL or MIME fallbacks (`image`/`download`) when needed.

### Testing
- Ran `python -m compileall zapzap/services/DownloadNamingService.py zapzap/services/DownloadManager.py zapzap/controllers/DownloadDialog.py` and compilation succeeded.  
- Executed an automated import-based validation script (via `importlib`) that asserts expected normalized filenames for JPEG, PNG, hidden names, URL fallback and non-image cases, and it passed.  
- Ran `git diff --check` as a repository consistency check and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d7eaf744832bb66a393841f50de3)