### PR TITLE
Fix cursor stuck in busy state after opening notification

### DIFF
--- a/share/applications/com.rtosta.zapzap.desktop
+++ b/share/applications/com.rtosta.zapzap.desktop
@@ -11,6 +11,7 @@ Keywords=WhatsApp;Chat;ZapZap;
 StartupWMClass=zapzap
 MimeType=x-scheme-handler/whatsapp
 Terminal=false
+StartupNotify=false
 SingleMainWindow=true
 X-GNOME-UsesNotifications=true
 X-GNOME-SingleWindow=true

--- a/zapzap/notifications/FreedesktopNotificationBackend.py
+++ b/zapzap/notifications/FreedesktopNotificationBackend.py
@@ -5,13 +5,13 @@ from collections import OrderedDict
 
 from PyQt6.QtCore import Qt, QSize, QStandardPaths
 from PyQt6.QtGui import QPainter, QImage, QBrush, QPen
-from PyQt6.QtWidgets import QApplication
 from PyQt6.QtWebEngineCore import QWebEngineNotification
 
 from zapzap.webengine import WebView
 from zapzap.resources.TrayIcon import TrayIcon
 from zapzap.services.SettingsManager import SettingsManager
 from zapzap import __appname__
+from zapzap.notifications.NotificationActivation import activate_notification_page
 
 # -----------------------------------------------------------------------------
 # Optional DBus imports (fail-safe)
@@ -114,6 +114,7 @@ class DBusConnection:
         self.interface = None
         self.available = False
         self._notifications: dict[int, DBusNotification] = {}
+        self._activation_tokens: dict[int, str] = {}
 
         self._init()
 
@@ -134,6 +135,9 @@ class DBusConnection:
 
             self.interface.connect_to_signal(
                 "ActionInvoked", self._on_action_invoked
+            )
+            self.interface.connect_to_signal(
+                "ActivationToken", self._on_activation_token
             )
             self.interface.connect_to_signal(
                 "NotificationClosed", self._on_notification_closed
@@ -192,17 +196,22 @@ class DBusConnection:
     # ------------------------------------------------------------------
     # DBus callbacks
     # ------------------------------------------------------------------
+    def _on_activation_token(self, nid, activation_token):
+        self._activation_tokens[int(nid)] = str(activation_token)
+
     def _on_action_invoked(self, nid, action):
         nid = int(nid)
         action = str(action)
         if nid in self._notifications:
-            self._notifications[nid].handle_action(action)
+            activation_token = self._activation_tokens.pop(nid, None)
+            self._notifications[nid].handle_action(action, activation_token)
 
     def _on_notification_closed(self, nid, _reason):
         nid = int(nid)
         if nid in self._notifications:
             self._notifications[nid].handle_closed()
             del self._notifications[nid]
+        self._activation_tokens.pop(nid, None)
 
 
 # -----------------------------------------------------------------------------
@@ -255,10 +264,10 @@ class DBusNotification:
             arr.extend([key, label])
         return arr
 
-    def handle_action(self, action: str):
+    def handle_action(self, action: str, activation_token: str | None = None):
         if action in self.actions:
             _, callback = self.actions[action]
-            callback()
+            callback(activation_token)
 
     def handle_closed(self):
         pass
@@ -316,16 +325,12 @@ class FreedesktopNotificationBackend:
         notify.set_category("im.received")
         notify.setIconPath(icon_path)  # 👈 ESSENCIAL
 
-        def on_click():
-            main = QApplication.instance().getWindow()
-            main.show()
-            main.raise_()
-            main.activateWindow()
-            main.browser.switch_to_page(
-                page,
-                main.browser.page_buttons[page.page_index],
+        def on_click(activation_token=None):
+            activate_notification_page(
+                page=page,
+                notification=notification,
+                activation_token=activation_token,
             )
-            notification.click()
 
         notify.add_action("default", "", on_click)
 

--- a/zapzap/notifications/NotificationActivation.py
+++ b/zapzap/notifications/NotificationActivation.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QApplication
+
+if TYPE_CHECKING:
+    from PyQt6.QtWebEngineCore import QWebEngineNotification
+
+    from zapzap.webengine.WebView import WebView
+
+
+def activate_notification_page(
+    page: WebView | None,
+    notification: QWebEngineNotification | None = None,
+    activation_token: str | None = None,
+) -> None:
+    """
+    Focus ZapZap after the user activates a desktop notification.
+
+    On Wayland, compositors can issue an XDG activation token with the
+    notification action. Qt's Wayland backend consumes that token from the
+    XDG_ACTIVATION_TOKEN environment variable when requestActivate() runs;
+    forwarding it prevents GNOME from leaving the pointer in the launch/busy
+    state after the notification is opened.
+    """
+    app = QApplication.instance()
+    if not app:
+        return
+
+    main_window = app.getWindow()
+    if not main_window:
+        return
+
+    if activation_token:
+        os.environ["XDG_ACTIVATION_TOKEN"] = activation_token
+
+    main_window.show()
+    if main_window.isMinimized():
+        main_window.showNormal()
+
+    main_window.setWindowState(
+        main_window.windowState()
+        & ~Qt.WindowState.WindowMinimized
+        | Qt.WindowState.WindowActive
+    )
+
+    if page is not None:
+        main_window.browser.switch_to_page(
+            page,
+            main_window.browser.page_buttons[page.page_index],
+        )
+
+    main_window.raise_()
+    main_window.activateWindow()
+
+    window = main_window.windowHandle()
+    if window is not None:
+        window.requestActivate()
+
+    if notification:
+        notification.click()
+
+
+def extract_activation_token(parameters) -> str | None:
+    """Return the XDG activation token from portal ActionInvoked parameters."""
+    for parameter in parameters or []:
+        value = _unwrap_dbus_value(parameter)
+        if isinstance(value, dict):
+            token = value.get("activation-token") or value.get("desktop-startup-id")
+            token = _unwrap_dbus_value(token)
+            if token:
+                return str(token)
+    return None
+
+
+def _unwrap_dbus_value(value):
+    if hasattr(value, "variant"):
+        return _unwrap_dbus_value(value.variant())
+    if hasattr(value, "value"):
+        attr = value.value
+        return _unwrap_dbus_value(attr() if callable(attr) else attr)
+    return value

--- a/zapzap/notifications/PortalNotificationBackend.py
+++ b/zapzap/notifications/PortalNotificationBackend.py
@@ -10,11 +10,13 @@ from PyQt6.QtDBus import (
     QDBusVariant,
 )
 from PyQt6.QtWebEngineCore import QWebEngineNotification
-from PyQt6.QtWidgets import QApplication
-
 from zapzap.webengine import WebView
 from zapzap.notifications.FreedesktopNotificationBackend import IconRenderer
 from zapzap.services.SettingsManager import SettingsManager
+from zapzap.notifications.NotificationActivation import (
+    activate_notification_page,
+    extract_activation_token,
+)
 
 
 class PortalNotificationBackend(QObject):
@@ -201,29 +203,15 @@ class PortalNotificationBackend(QObject):
             return
 
         try:
-            app = QApplication.instance()
-            if not app:
-                return
-
-            main_window = app.getWindow()
-            if not main_window:
-                return
-
-            main_window.show()
-            main_window.raise_()
-            main_window.activateWindow()
-
             notification = self._notifications.get(notification_id)
             page = self._pages.get(notification_id)
+            activation_token = extract_activation_token(parameters)
 
-            if page is not None:
-                main_window.browser.switch_to_page(
-                    page,
-                    main_window.browser.page_buttons[page.page_index]
-                )
-
-            if notification:
-                notification.click()
+            activate_notification_page(
+                page=page,
+                notification=notification,
+                activation_token=activation_token,
+            )
 
         except Exception as e:
             print("Portal ActionInvoked error:", e)


### PR DESCRIPTION
### Motivation

- Fix an issue where the pointer/cursor could remain in a spinning/busy state after the user opened a desktop notification, notably on Wayland/GNOME where XDG activation tokens need to be forwarded to Qt before activating the window. 
- Ensure the app correctly focuses the main window and switches to the relevant chat/page while preserving compositor activation tokens so the launcher/compositor can clear the busy pointer.

### Description

- Add a new helper module `zapzap/notifications/NotificationActivation.py` that forwards an XDG activation token via `XDG_ACTIVATION_TOKEN`, focuses the main window, switches to the target `WebView` page, calls `requestActivate()` and triggers the `QWebEngineNotification.click()` when appropriate. 
- Update `PortalNotificationBackend` to extract `activation-token`/`desktop-startup-id` from portal `ActionInvoked` parameters and call the shared activation helper. 
- Update `FreedesktopNotificationBackend` to capture `ActivationToken` DBus signals, store tokens per notification id, pass tokens into notification action callbacks, and route clicks through the shared activation helper. 
- Adjust `DBusNotification.handle_action` to accept an optional `activation_token` parameter and replace duplicated `QApplication` checks with the centralized activation helper.

### Testing

- Compiled the modified modules with `python -m py_compile zapzap/notifications/NotificationActivation.py zapzap/notifications/PortalNotificationBackend.py zapzap/notifications/FreedesktopNotificationBackend.py`, which succeeded. 
- Ran `python -m compileall -q zapzap` to compile the package, which succeeded. 
- Ran `git diff --check` to catch whitespace/patch issues, which returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22db180b30832b82c795dfe1007e3d)