### PR TITLE
Fix pl.po duplicate message definition

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -746,7 +746,3 @@ msgstr "Pokaż"
 #: zapzap/services/SysTrayManager.py:56
 msgid "Donation"
 msgstr "Darowizna"
-
-#, python-brace-format
-#~ msgid "Version {id}"
-#~ msgstr "Wersja {id}"


### PR DESCRIPTION
@mkarenko I would like to fill you in on this as well. You're the Polish translator for ZapZap.

I attempted to build zapzap on Slackware-current, but I found the following build failure:
```
creating locale/pl/LC_MESSAGES
Compile: po/pl.po -> locale/pl/LC_MESSAGES/zapzap.mo
msgfmt -o locale/pl/LC_MESSAGES/zapzap.mo po/pl.po
po/pl.po:751: duplicate message definition...
po/pl.po:471: ...this is the location of the first definition
/usr/bin/msgfmt: found 1 fatal error
error: command '/usr/bin/msgfmt' failed with exit code 1
```

These are lines 468-471 of pl.po:
```
#: zapzap/views/ui_qtoaster_donation.py:138
#, python-brace-format
msgid "Version {id}"
msgstr "Wersja {id}"
```

These are lines 750-752 of pl.po:
```
#, python-brace-format
#~ msgid "Version {id}"
#~ msgstr "Wersja {id}"
```

After removing lines 749-752 (the change I am proposing in this pull request), I was able to compile zapzap.

I don't know Polish.
I am only suggesting this change to fix a build failure I have experienced.

If there are better ways to fix this "duplicate message definition" error, please apply them instead.