### PR TITLE
Fix Snap desktop launcher integration

### DIFF
--- a/builders/snap/snapcraft.yaml
+++ b/builders/snap/snapcraft.yaml
@@ -14,6 +14,7 @@ layout:
 apps:
   zapzap:
     command: usr/bin/zapzap
+    desktop: usr/share/applications/com.rtosta.zapzap.desktop
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libproxy:$SNAP/usr/lib/x86_64-linux-gnu/libproxy:$SNAP/usr/lib/aarch64-linux-gnu/libproxy:$LD_LIBRARY_PATH
       PYTHONPATH: $SNAP/usr/local/lib/python3.12/dist-packages:$SNAP/usr/local/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12/dist-packages:$PYTHONPATH
@@ -64,3 +65,6 @@ parts:
       export DESTDIR="$CRAFT_PART_INSTALL"
       export PREFIX=/usr
       prepare_package
+      install -Dm644 share/applications/com.rtosta.zapzap.desktop "$CRAFT_PART_INSTALL/usr/share/applications/com.rtosta.zapzap.desktop"
+      install -Dm644 share/icons/com.rtosta.zapzap.svg "$CRAFT_PART_INSTALL/usr/share/icons/hicolor/scalable/apps/com.rtosta.zapzap.svg"
+      install -Dm644 share/metainfo/com.rtosta.zapzap.appdata.xml "$CRAFT_PART_INSTALL/usr/share/metainfo/com.rtosta.zapzap.appdata.xml"


### PR DESCRIPTION
### Motivation
- The Snap build did not declare or install the `.desktop` launcher and related metadata, causing the app not to appear in desktop application grids.

### Description
- Added `desktop: usr/share/applications/com.rtosta.zapzap.desktop` to the `zapzap` app entry in `builders/snap/snapcraft.yaml` to tell snapcraft which desktop file to export.
- Added `install -Dm644 ...` steps in the `override-build` section to include the desktop entry, scalable SVG icon, and AppStream metadata inside the Snap payload.

### Testing
- Ran a Ruby YAML check `ruby -ryaml -e 'data = YAML.load_file("builders/snap/snapcraft.yaml"); raise unless data.dig("apps", "zapzap", "desktop") == "usr/share/applications/com.rtosta.zapzap.desktop"; puts "valid yaml"'` which succeeded.
- Ran a Python assertion that checks the presence of the `desktop` key and the three `install -Dm644` lines in `builders/snap/snapcraft.yaml` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d780b9b44832bab21450509019fb1)