### PR TITLE
Fix Snap launcher icon

### DIFF
--- a/builders/snap/snapcraft.yaml
+++ b/builders/snap/snapcraft.yaml
@@ -6,6 +6,7 @@ confinement: strict
 summary: WhatsApp desktop client web app
 description: |
   ZapZap is a WhatsApp desktop client web app.
+icon: share/icons/com.rtosta.zapzap.svg
 
 layout:
   /usr/share/X11/xkb:
@@ -66,5 +67,7 @@ parts:
       export PREFIX=/usr
       prepare_package
       install -Dm644 share/applications/com.rtosta.zapzap.desktop "$CRAFT_PART_INSTALL/usr/share/applications/com.rtosta.zapzap.desktop"
+      sed -i 's|^Icon=.*|Icon=${SNAP}/meta/gui/icon.svg|' "$CRAFT_PART_INSTALL/usr/share/applications/com.rtosta.zapzap.desktop"
+      install -Dm644 share/icons/com.rtosta.zapzap.svg "$CRAFT_PART_INSTALL/meta/gui/icon.svg"
       install -Dm644 share/icons/com.rtosta.zapzap.svg "$CRAFT_PART_INSTALL/usr/share/icons/hicolor/scalable/apps/com.rtosta.zapzap.svg"
       install -Dm644 share/metainfo/com.rtosta.zapzap.appdata.xml "$CRAFT_PART_INSTALL/usr/share/metainfo/com.rtosta.zapzap.appdata.xml"


### PR DESCRIPTION
### Motivation
- Users installing via Snap saw a generic gear icon because the launcher could not find the bundled app icon inside the snap. 
- The snap package needs an explicit `icon` metadata entry and a bundled GUI icon so desktop environments can display the correct launcher icon.

### Description
- Added `icon: share/icons/com.rtosta.zapzap.svg` to `builders/snap/snapcraft.yaml` so the snap has an explicit package icon.
- Modified the `override-build` step to rewrite the desktop file `Icon=` line to `Icon=${SNAP}/meta/gui/icon.svg` with `sed` so the launcher points to the bundled icon inside the snap.
- Installed the application SVG into `meta/gui/icon.svg` and preserved installation into the hicolor icon path for compatibility.

### Testing
- Ran a desktop file rewrite assertion with `python` to verify the `Icon=` replacement logic and it passed.
- Parsed `builders/snap/snapcraft.yaml` with `ruby` to ensure the `icon` key is present and it passed.
- Ran `git diff --check` to validate whitespace/format issues and it passed.
- Attempted to parse the YAML with `python` and `PyYAML` but the check was skipped because `PyYAML` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8101d1a8832b9612ee756e1dc322)