### PR TITLE
Workflow: document and publish Snap to Snap Store on GitHub release

### DIFF
--- a/.github/workflows/readme.md
+++ b/.github/workflows/readme.md
@@ -1,0 +1,32 @@
+# Workflows
+
+## Publicação do Snap
+
+O workflow `release.yml` compila o pacote Snap e publica na Snap Store somente
+quando uma GitHub Release normal é publicada.
+
+### Comportamento final
+
+| Evento | Build snap | Anexa `.snap` na GitHub Release | Publica na Snapcraft |
+| --- | ---: | ---: | ---: |
+| `workflow_dispatch` com `publish = false` | Sim | Não, só artifact | Não |
+| `workflow_dispatch` com `publish = true` | Sim | Sim | Não |
+| `push` de tag | Sim | Sim | Não |
+| GitHub pre-release publicada | Sim | Sim | Não |
+| GitHub release normal publicada | Sim | Sim | Sim, em `stable` |
+
+### Secret necessário
+
+Para publicar na Snap Store, configure o secret `STORE_LOGIN` em:
+
+```text
+Settings -> Secrets and variables -> Actions -> New repository secret
+```
+
+O valor do secret deve ser gerado uma vez em uma máquina com Snapcraft
+autenticado:
+
+```bash
+snapcraft login
+snapcraft export-login --snaps zapzap --channels stable -
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - "true"
 
   release:
-    types: [created]
+    types: [published]
 
   push:
     tags:
@@ -342,6 +342,14 @@ jobs:
           files: ${{ steps.normalized_snap.outputs.snap }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Snap to Snap Store stable
+        if: github.event_name == 'release' && github.event.release.prerelease == false
+        uses: snapcore/action-publish@v1
+        with:
+          store_login: ${{ secrets.STORE_LOGIN }}
+          snap: ${{ steps.normalized_snap.outputs.snap }}
+          release: stable
 
 # ==========================================================
 # DEB


### PR DESCRIPTION
### Motivation

- Document repository workflows and Snap publish behavior with a new ` .github/workflows/readme.md` file in Portuguese. 
- Ensure the Snap is published to the Snap Store only when a GitHub release is fully `published` (not on pre-releases). 
- Clarify and refine `workflow_dispatch` behavior so manual runs can upload artifacts without publishing unless `publish = true`.

### Description

- Add ` .github/workflows/readme.md` describing the `release.yml` behavior and how to set the `STORE_LOGIN` secret. 
- Change the `release` trigger in ` .github/workflows/release.yml` from `types: [created]` to `types: [published]` to target published releases. 
- Add a `Publish Snap to Snap Store stable` step using `snapcore/action-publish@v1` that runs only when `github.event_name == 'release'` and `github.event.release.prerelease == false`, passing the snap path and `STORE_LOGIN` secret and publishing to `stable`. 
- Preserve the existing artifact upload and GitHub release attachment logic for `workflow_dispatch` vs release/tag flows and apply a minor whitespace/newline fix.

### Testing

- No automated tests were executed as part of this change in the provided rollout; CI pipeline steps such as `Test Package` remain present in the workflow but were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8021a644832b8658817c9c3a5116)