### PR TITLE
Publish Snap to Snap Store on published releases and add workflows README

### DIFF
--- a/.github/workflows/readme.md
+++ b/.github/workflows/readme.md
@@ -1,0 +1,32 @@
+# Workflows
+
+## Publicação do Snap
+
+O workflow `release.yml` compila o pacote Snap e publica na Snap Store somente
+quando uma GitHub Release normal é publicada.
+
+### Comportamento final
+
+| Evento | Build snap | Anexa `.snap` na GitHub Release | Publica na Snapcraft |
+| --- | ---: | ---: | ---: |
+| `workflow_dispatch` com `publish = false` | Sim | Não, só artifact | Não |
+| `workflow_dispatch` com `publish = true` | Sim | Sim | Não |
+| `push` de tag | Sim | Sim | Não |
+| GitHub pre-release publicada | Sim | Sim | Não |
+| GitHub release normal publicada | Sim | Sim | Sim, em `stable` |
+
+### Secret necessário
+
+Para publicar na Snap Store, configure o secret `STORE_LOGIN` em:
+
+```text
+Settings -> Secrets and variables -> Actions -> New repository secret
+```
+
+O valor do secret deve ser gerado uma vez em uma máquina com Snapcraft
+autenticado e será usado no workflow como `SNAPCRAFT_STORE_CREDENTIALS`:
+
+```bash
+snapcraft login
+snapcraft export-login --snaps zapzap --channels stable -
+```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - "true"
 
   release:
-    types: [created]
+    types: [published]
 
   push:
     tags:
@@ -342,6 +342,13 @@ jobs:
           files: ${{ steps.normalized_snap.outputs.snap }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Snap to Snap Store stable
+        if: github.event_name == 'release' && github.event.release.prerelease == false
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}
+        run: |
+          snapcraft upload --release=stable "${{ steps.normalized_snap.outputs.snap }}"
 
 # ==========================================================
 # DEB


### PR DESCRIPTION
### Motivation

- Ensure the Snap artifact is uploaded to the Snap Store only when a GitHub Release is published (not on draft/prerelease) and document the workflows.
- Provide guidance for configuring the Snap Store credentials required by the workflow.

### Description

- Add `.github/workflows/readme.md` documenting the `release.yml` workflow behavior and the required `STORE_LOGIN` secret and how to generate it.
- Change the `release` trigger in `.github/workflows/release.yml` from `created` to `published` so the workflow reacts to published releases only.
- Add a `Publish Snap to Snap Store stable` step that runs on the `release` event when `prerelease == false`, using `SNAPCRAFT_STORE_CREDENTIALS` from the `STORE_LOGIN` secret and calling `snapcraft upload --release=stable` on the built snap.
- Preserve existing artifact upload and GitHub release attachment behavior for `workflow_dispatch` and tag pushes, and fix minor EOF whitespace.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d8021a644832b8658817c9c3a5116)