### PR TITLE
Add Snap build, common packaging helpers, and normalize release artifact names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,6 +206,21 @@ jobs:
         run: |
           /bin/sh ./builders/anylinux-appimage/make-appimage.sh
 
+      - name: Normalize AnyLinux artifact names
+        run: |
+          VERSION=$(cat ~/version)
+          APPIMAGE_NAME="ZapZap-${VERSION}-linux-${{ matrix.arch }}.AppImage"
+
+          appimage=$(find dist -maxdepth 1 -name "*.AppImage" -print -quit)
+          if [ -n "$appimage" ]; then
+            mv "$appimage" "dist/${APPIMAGE_NAME}"
+          fi
+
+          zsync=$(find dist -maxdepth 1 -name "*.zsync" -print -quit)
+          if [ -n "$zsync" ]; then
+            mv "$zsync" "dist/${APPIMAGE_NAME}.zsync"
+          fi
+
       - name: List generated files
         run: |
           ls -lah dist/
@@ -233,6 +248,94 @@ jobs:
             dist/*.AppImage
             dist/*.zsync
             
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
+# ==========================================================
+# SNAP
+# ==========================================================
+
+  build-snap:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create BuildInfo.py
+        shell: bash
+        run: |
+          cat > zapzap/BuildInfo.py << EOF_BUILD_INFO
+          BUILD_CHANNEL = "Official"
+          BUILD_PROVIDER = "GitHub Actions"
+          BUILD_REPOSITORY = "${{ github.repository }}"
+          EOF_BUILD_INFO
+
+      - name: Prepare Snapcraft project
+        run: |
+          rm -rf .snapcraft-project
+          mkdir -p .snapcraft-project
+          rsync -a \
+            --exclude .git \
+            --exclude .snapcraft-project \
+            ./ \
+            .snapcraft-project/
+          cp builders/snap/snapcraft.yaml .snapcraft-project/snapcraft.yaml
+
+      - name: Build Snap
+        id: snapcraft
+        uses: snapcore/action-build@v1
+        with:
+          path: .snapcraft-project
+
+      - name: List generated Snap
+        run: |
+          ls -lah "${{ steps.snapcraft.outputs.snap }}"
+
+      - name: Normalize Snap artifact name
+        id: normalized_snap
+        run: |
+          VERSION=$(python - <<'PY_VERSION'
+          from pathlib import Path
+          import ast
+
+          init_py = Path("zapzap") / "__init__.py"
+          for node in ast.parse(init_py.read_text(encoding="utf-8")).body:
+              if isinstance(node, ast.Assign):
+                  for target in node.targets:
+                      if isinstance(target, ast.Name) and target.id == "__version__":
+                          print(ast.literal_eval(node.value))
+                          raise SystemExit
+          raise SystemExit("__version__ not found")
+          PY_VERSION
+          )
+          ARCH=$(dpkg --print-architecture)
+          SNAP_NAME="ZapZap-${VERSION}-linux-${ARCH}.snap"
+          mkdir -p dist
+          cp "${{ steps.snapcraft.outputs.snap }}" "dist/${SNAP_NAME}"
+          echo "snap=dist/${SNAP_NAME}" >> "$GITHUB_OUTPUT"
+
+      # ======================================================
+      # Manual execution -> upload artifact only
+      # ======================================================
+
+      - name: Upload Snap artifact
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ZapZap-Snap-linux-amd64
+          path: ${{ steps.normalized_snap.outputs.snap }}
+
+      # ======================================================
+      # Release/tag -> publish release
+      # ======================================================
+
+      - name: Release Snap artifact
+        if: github.event_name != 'workflow_dispatch' || github.event.inputs.publish == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ steps.normalized_snap.outputs.snap }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -380,18 +483,18 @@ jobs:
           dpkg-deb \
             --root-owner-group \
             --build package \
-            zapzap_${{ steps.version.outputs.version }}_amd64.deb
+            ZapZap-${{ steps.version.outputs.version }}-linux-amd64.deb
       
       - name: List Package Contents
         run: |
           dpkg-deb --contents \
-            zapzap_${{ steps.version.outputs.version }}_amd64.deb \
+            ZapZap-${{ steps.version.outputs.version }}-linux-amd64.deb \
             | head -200
       
       - name: Test Package
         run: |
           dpkg-deb --info \
-            zapzap_${{ steps.version.outputs.version }}_amd64.deb
+            ZapZap-${{ steps.version.outputs.version }}-linux-amd64.deb
 
       - name: Verify AppRun
         run: |
@@ -401,15 +504,15 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: zapzap-deb-amd64
+          name: ZapZap-DEB-linux-amd64
           path: |
-            *.deb
+            ZapZap-*-linux-amd64.deb
       
       - name: Release DEB artifact
         if: github.event_name != 'workflow_dispatch' || github.event.inputs.publish == 'true'
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            *.deb
+            ZapZap-*-linux-amd64.deb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/builders/anylinux-appimage/get-dependencies.sh
+++ b/builders/anylinux-appimage/get-dependencies.sh
@@ -2,9 +2,12 @@
 
 set -eu
 
-echo "Installing package dependencies..."
-echo "---------------------------------------------------------------"
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT_DIR=$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)
 
+. "${ROOT_DIR}/builders/common/common.sh"
+
+log "Installing package dependencies"
 pacman -Syu --noconfirm \
     base-devel \
     ffmpeg \
@@ -25,51 +28,23 @@ pacman -Syu --noconfirm \
     python-pyqt6 \
     python-pyqt6-webengine
 
-
-echo "Installing debloated packages..."
-echo "---------------------------------------------------------------"
-
+log "Installing debloated packages"
 get-debloated-pkgs --add-common --prefer-nano ffmpeg-mini
 
-echo "Downloading dictionaries..."
-git clone \
-  --depth=1 \
-  https://github.com/rafatosta/qtwebengine_dictionaries.git
+log "Downloading dictionaries"
+if [ ! -d "${ROOT_DIR}/qtwebengine_dictionaries" ]; then
+    git clone \
+      --depth=1 \
+      https://github.com/rafatosta/qtwebengine_dictionaries.git \
+      "${ROOT_DIR}/qtwebengine_dictionaries"
+fi
 
-mkdir -p zapzap/qtwebengine_dictionaries
+export DESTDIR="${DESTDIR:-${ROOT_DIR}/AppDir}"
+export PREFIX="${PREFIX:-/usr}"
 
-cp \
-  qtwebengine_dictionaries/*.bdic \
-  zapzap/qtwebengine_dictionaries/
+prepare_package
 
-echo "Building ZapZap..."
-echo "---------------------------------------------------------------"
+log "Saving version"
+project_version > "${HOME}/version"
 
-python -m build
-
-echo "Installing ZapZap..."
-echo "---------------------------------------------------------------"
-
-python -m installer dist/*.whl
-
-echo "Checking installation..."
-echo "---------------------------------------------------------------"
-
-which zapzap
-
-zapzap --help >/dev/null 2>&1 || true
-
-echo "Saving version..."
-echo "---------------------------------------------------------------"
-
-python - <<'EOF' > ~/version
-from pathlib import Path
-
-wheel = next(Path("dist").glob("zapzap-*.whl"))
-
-version = wheel.name.split("-")[1]
-
-print(version)
-EOF
-
-echo "Done."
+log "Done"

--- a/builders/anylinux-appimage/make-appimage.sh
+++ b/builders/anylinux-appimage/make-appimage.sh
@@ -38,32 +38,16 @@ mkdir -p "${OUTPATH}"
 echo "Arquitetura: ${ARCH}"
 echo "Gerando AppImage AnyLinux..."
 
-ZAPZAP_BIN="$(command -v zapzap)"
+APPDIR="./AppDir"
+ZAPZAP_BIN="${APPDIR}/usr/bin/zapzap"
 
-if [ -z "${ZAPZAP_BIN}" ]; then
-    echo "Erro: executável zapzap não encontrado."
+if [ ! -x "${ZAPZAP_BIN}" ]; then
+    echo "Erro: executável zapzap não encontrado em ${ZAPZAP_BIN}."
+    echo "Execute get-dependencies.sh para preparar a instalação em DESTDIR antes de empacotar."
     exit 1
 fi
 
-echo "Executável encontrado em: ${ZAPZAP_BIN}"
-
-echo
-echo "==============================================================="
-echo "Verificando dicionários instalados"
-echo "==============================================================="
-
-DICT_SRC="$(python - <<'EOF'
-from importlib.resources import files
-
-path = files("zapzap") / "qtwebengine_dictionaries"
-
-print(path)
-EOF
-)"
-
-echo "Origem: ${DICT_SRC}"
-
-find "${DICT_SRC}" -name "*.bdic" | sort
+echo "Executável preparado em: ${ZAPZAP_BIN}"
 
 echo
 echo "==============================================================="
@@ -83,8 +67,6 @@ quick-sharun \
     /usr/lib/libQt6WebEngineWidgets.so* \
     /usr/lib/libQt6WebEngineCore.so*
 
-APPDIR="./AppDir"
-
 find /usr/lib -name "libQt6WebEngineWidgets.so*"
 
 mkdir -p "${APPDIR}/lib"
@@ -96,23 +78,6 @@ if [ ! -d "${APPDIR}" ]; then
     echo "Erro: AppDir não encontrado."
     exit 1
 fi
-
-echo
-echo "==============================================================="
-echo "Copiando dicionários para o AppDir"
-echo "==============================================================="
-
-DICT_DST="${APPDIR}/qtwebengine_dictionaries"
-
-mkdir -p "${DICT_DST}"
-
-cp -av \
-    "${DICT_SRC}"/*.bdic \
-    "${DICT_DST}/"
-
-echo
-echo "Dicionários no AppDir:"
-find "${APPDIR}" -name "*.bdic" | sort
 
 echo
 echo "==============================================================="

--- a/builders/common/common.sh
+++ b/builders/common/common.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+
+set -eu
+
+ROOT_DIR=${ROOT_DIR:-$(pwd)}
+DIST_DIR=${DIST_DIR:-"${ROOT_DIR}/dist"}
+DESTDIR=${DESTDIR:-}
+PREFIX=${PREFIX:-/usr}
+PYTHON=${PYTHON:-python3}
+
+log() {
+    printf '\n==> %s\n' "$*"
+}
+
+_require_destdir() {
+    if [ -z "${DESTDIR}" ]; then
+        echo "DESTDIR must be set before installing." >&2
+        exit 1
+    fi
+
+    case "${DESTDIR}" in
+        /|/usr|/usr/|/usr/local|/usr/local/)
+            echo "Refusing to install into host filesystem DESTDIR=${DESTDIR}" >&2
+            exit 1
+            ;;
+    esac
+}
+
+build_wheel() {
+    log "Building wheel"
+    mkdir -p "${DIST_DIR}"
+    rm -f "${DIST_DIR}"/*.whl
+    (cd "${ROOT_DIR}" && "${PYTHON}" -Im build --wheel --outdir "${DIST_DIR}")
+}
+
+_find_wheel() {
+    set -- "${DIST_DIR}"/*.whl
+    if [ ! -e "$1" ]; then
+        echo "No wheel found in ${DIST_DIR}" >&2
+        exit 1
+    fi
+    if [ "$#" -ne 1 ]; then
+        echo "Expected exactly one wheel in ${DIST_DIR}, found $#" >&2
+        exit 1
+    fi
+    printf '%s\n' "$1"
+}
+
+install_wheel() {
+    _require_destdir
+    wheel=$(_find_wheel)
+    log "Installing wheel into ${DESTDIR}"
+    mkdir -p "${DESTDIR}"
+    "${PYTHON}" -Im installer --destdir "${DESTDIR}" --prefix "${PREFIX}" "${wheel}"
+    _normalize_executable
+    _normalize_python_package
+}
+
+_normalize_executable() {
+    expected_bin="${DESTDIR}${PREFIX}/bin/zapzap"
+
+    if [ -x "${expected_bin}" ]; then
+        return 0
+    fi
+
+    installed_bin=$(find "${DESTDIR}" -type f -path "*/bin/zapzap" -perm -111 | head -n 1)
+
+    if [ -n "${installed_bin}" ]; then
+        log "Normalizing executable path to ${expected_bin}"
+        mkdir -p "$(dirname "${expected_bin}")"
+        cp -f "${installed_bin}" "${expected_bin}"
+        chmod 755 "${expected_bin}"
+    fi
+}
+
+_normalize_python_package() {
+    expected_site="${DESTDIR}${PREFIX}/lib/python3/dist-packages"
+
+    if [ -f "${expected_site}/zapzap/__init__.py" ]; then
+        return 0
+    fi
+
+    installed_init=$(find "${DESTDIR}" -type f -path "*/zapzap/__init__.py" | head -n 1)
+
+    if [ -z "${installed_init}" ]; then
+        return 0
+    fi
+
+    installed_package=$(dirname "${installed_init}")
+    installed_site=$(dirname "${installed_package}")
+
+    log "Normalizing Python package path to ${expected_site}"
+    mkdir -p "${expected_site}"
+    cp -a "${installed_package}" "${expected_site}/"
+
+    for metadata in "${installed_site}"/zapzap-*.dist-info "${installed_site}"/zapzap-*.egg-info; do
+        [ -e "${metadata}" ] || continue
+        cp -a "${metadata}" "${expected_site}/"
+    done
+}
+
+project_version() {
+    "${PYTHON}" - <<EOF_PY
+from pathlib import Path
+import ast
+
+init_py = Path("${ROOT_DIR}") / "zapzap" / "__init__.py"
+for node in ast.parse(init_py.read_text(encoding="utf-8")).body:
+    if isinstance(node, ast.Assign):
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id == "__version__":
+                print(ast.literal_eval(node.value))
+                raise SystemExit
+raise SystemExit("__version__ not found")
+EOF_PY
+}
+
+find_qt_dir() {
+    "${PYTHON}" - <<'EOF_PY'
+from pathlib import Path
+candidates = [
+    Path('/usr/lib/qt6'),
+    Path('/usr/lib64/qt6'),
+    Path(f'/usr/lib/{__import__("platform").machine()}-linux-gnu/qt6'),
+    Path('/usr/lib/x86_64-linux-gnu/qt6'),
+]
+for path in candidates:
+    if path.exists():
+        print(path)
+        raise SystemExit
+raise SystemExit('Qt6 installation directory not found')
+EOF_PY
+}
+
+install_dictionaries() {
+    _require_destdir
+    log "Installing QtWebEngine dictionaries into ${DESTDIR}"
+    dict_dst="${DESTDIR}${PREFIX}/share/zapzap/qtwebengine_dictionaries"
+    mkdir -p "${dict_dst}"
+
+    if [ -d "${ROOT_DIR}/qtwebengine_dictionaries" ]; then
+        dict_src="${ROOT_DIR}/qtwebengine_dictionaries"
+    elif [ -d "${ROOT_DIR}/zapzap/qtwebengine_dictionaries" ]; then
+        dict_src="${ROOT_DIR}/zapzap/qtwebengine_dictionaries"
+    else
+        echo "No qtwebengine_dictionaries directory found; skipping." >&2
+        return 0
+    fi
+
+    found=0
+    for dict in "${dict_src}"/*.bdic; do
+        [ -e "${dict}" ] || continue
+        cp -f "${dict}" "${dict_dst}/"
+        found=1
+    done
+
+    if [ "${found}" -eq 0 ]; then
+        echo "No .bdic dictionaries found in ${dict_src}; skipping." >&2
+    fi
+}
+
+validate_install() {
+    _require_destdir
+    log "Validating installation in ${DESTDIR}"
+    [ -x "${DESTDIR}${PREFIX}/bin/zapzap" ] || {
+        echo "Missing executable: ${DESTDIR}${PREFIX}/bin/zapzap" >&2
+        exit 1
+    }
+
+    "${PYTHON}" - <<EOF_PY
+from pathlib import Path
+import sys
+root = Path("${DESTDIR}")
+matches = list(root.glob("**/site-packages/zapzap/__init__.py"))
+matches.extend(root.glob("**/dist-packages/zapzap/__init__.py"))
+if not matches:
+    sys.exit("Missing installed zapzap package under DESTDIR")
+EOF_PY
+}
+
+prepare_package() {
+    build_wheel
+    install_wheel
+    install_dictionaries
+    validate_install
+}

--- a/builders/deb/build.sh
+++ b/builders/deb/build.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT_DIR=$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)
+
+. "${ROOT_DIR}/builders/common/common.sh"
+
+PACKAGE_NAME=${PACKAGE_NAME:-zapzap}
+VERSION=$(project_version)
+ARCH=${ARCH:-$(dpkg --print-architecture)}
+BUILD_DIR=${BUILD_DIR:-"${ROOT_DIR}/.packaging/deb"}
+PACKAGE_ROOT="${BUILD_DIR}/${PACKAGE_NAME}_${VERSION}_${ARCH}"
+
+rm -rf "${PACKAGE_ROOT}"
+mkdir -p "${PACKAGE_ROOT}/DEBIAN" "${DIST_DIR}"
+
+export DESTDIR="${PACKAGE_ROOT}"
+export PREFIX="${PREFIX:-/usr}"
+
+prepare_package
+
+cat > "${PACKAGE_ROOT}/DEBIAN/control" <<CONTROL
+Package: ${PACKAGE_NAME}
+Version: ${VERSION}
+Section: net
+Priority: optional
+Architecture: ${ARCH}
+Maintainer: Rafael Tosta <rafa.ecomp@gmail.com>
+Depends: python3, python3-pyqt6, python3-pyqt6.qtwebengine
+Description: WhatsApp desktop client web app
+ ZapZap is a WhatsApp desktop client web app.
+CONTROL
+
+log "Building DEB package"
+dpkg-deb --build "${PACKAGE_ROOT}" "${DIST_DIR}/${PACKAGE_NAME}_${VERSION}_${ARCH}.deb"

--- a/builders/snap/build.sh
+++ b/builders/snap/build.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+ROOT_DIR=$(CDPATH= cd -- "${SCRIPT_DIR}/../.." && pwd)
+PROJECT_DIR=${SNAPCRAFT_PROJECT_DIR:-"${ROOT_DIR}/.snapcraft-project"}
+
+rm -rf "${PROJECT_DIR}"
+mkdir -p "${PROJECT_DIR}"
+
+rsync -a \
+    --exclude .git \
+    --exclude .snapcraft-project \
+    "${ROOT_DIR}/" \
+    "${PROJECT_DIR}/"
+
+cp "${SCRIPT_DIR}/snapcraft.yaml" "${PROJECT_DIR}/snapcraft.yaml"
+
+cd "${PROJECT_DIR}"
+snapcraft pack "$@"

--- a/builders/snap/snapcraft.yaml
+++ b/builders/snap/snapcraft.yaml
@@ -1,0 +1,66 @@
+name: zapzap
+base: core24
+adopt-info: zapzap
+grade: stable
+confinement: strict
+summary: WhatsApp desktop client web app
+description: |
+  ZapZap is a WhatsApp desktop client web app.
+
+layout:
+  /usr/share/X11/xkb:
+    bind: $SNAP/usr/share/X11/xkb
+
+apps:
+  zapzap:
+    command: usr/bin/zapzap
+    environment:
+      LD_LIBRARY_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libproxy:$SNAP/usr/lib/x86_64-linux-gnu/libproxy:$SNAP/usr/lib/aarch64-linux-gnu/libproxy:$LD_LIBRARY_PATH
+      PYTHONPATH: $SNAP/usr/local/lib/python3.12/dist-packages:$SNAP/usr/local/lib/python3.12/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.12/dist-packages:$PYTHONPATH
+      QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins:$SNAP/usr/lib/x86_64-linux-gnu/qt6/plugins:$SNAP/usr/lib/aarch64-linux-gnu/qt6/plugins:$QT_PLUGIN_PATH
+      QT_QPA_PLATFORM_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins/platforms:$SNAP/usr/lib/x86_64-linux-gnu/qt6/plugins/platforms:$SNAP/usr/lib/aarch64-linux-gnu/qt6/plugins/platforms:$QT_QPA_PLATFORM_PLUGIN_PATH
+      QTWEBENGINEPROCESS_PATH: $SNAP/usr/lib/qt6/libexec/QtWebEngineProcess
+      QTWEBENGINE_RESOURCES_PATH: $SNAP/usr/share/qt6/resources
+      QTWEBENGINE_LOCALES_PATH: $SNAP/usr/share/qt6/translations/qtwebengine_locales
+      QTWEBENGINE_DISABLE_SANDBOX: "1"
+      QTWEBENGINE_CHROMIUM_FLAGS: --no-sandbox --disable-gpu-sandbox --password-store=basic
+      QTWEBENGINE_DICTIONARIES_PATH: $SNAP/usr/share/zapzap/qtwebengine_dictionaries
+      XKB_CONFIG_ROOT: $SNAP/usr/share/X11/xkb
+    plugs:
+      - desktop
+      - desktop-legacy
+      - wayland
+      - x11
+      - network
+      - audio-playback
+      - browser-support
+
+parts:
+  zapzap:
+    plugin: dump
+    source: .
+    build-packages:
+      - git
+      - python3-build
+      - python3-installer
+      - python3-venv
+    stage-packages:
+      - libxcb-cursor0
+      - python3
+      - python3-pyqt6
+      - python3-pyqt6.qtsvg
+      - python3-pyqt6.qtwebengine
+      - libqt6svg6
+      - qt6-wayland
+      - xkb-data
+    override-build: |
+      set -eu
+      cd "$CRAFT_PART_SRC"
+      . builders/common/common.sh
+      craftctl set version="$(project_version)"
+      if [ ! -d qtwebengine_dictionaries ]; then
+        git clone --depth=1 https://github.com/rafatosta/qtwebengine_dictionaries.git
+      fi
+      export DESTDIR="$CRAFT_PART_INSTALL"
+      export PREFIX=/usr
+      prepare_package

--- a/zapzap/services/EnvironmentManager.py
+++ b/zapzap/services/EnvironmentManager.py
@@ -6,6 +6,7 @@ from enum import Enum
 class Packaging(Enum):
     APPIMAGE   = "AppImage"
     FLATPAK    = "Flatpak"
+    SNAP       = "Snap"
     RPM        = "RPM"
     UNOFFICIAL = "Unofficial"
     WINDOWS    = "Windows"
@@ -19,7 +20,9 @@ class EnvironmentManager:
         if sys.platform == "win32":
             return Packaging.WINDOWS
 
-        if "APPIMAGE" in os.environ:
+        if "SNAP" in os.environ:
+            return Packaging.SNAP
+        elif "APPIMAGE" in os.environ:
             return Packaging.APPIMAGE
         elif "FLATPAK_ID" in os.environ:
             return Packaging.FLATPAK

--- a/zapzap/services/PathManager.py
+++ b/zapzap/services/PathManager.py
@@ -14,6 +14,16 @@ class PathManager:
             "path": "",
             "default": os.getenv("QTWEBENGINE_DICTIONARIES_PATH", ""),
         },
+        Packaging.SNAP: {
+            "path": "",
+            "default": os.getenv(
+                "QTWEBENGINE_DICTIONARIES_PATH",
+                os.path.join(
+                    os.getenv("SNAP", "/"),
+                    "usr/share/zapzap/qtwebengine_dictionaries",
+                ),
+            ),
+        },
         Packaging.RPM: {
             "path": "",
             "default": "/usr/share/qt6/qtwebengine_dictionaries",

--- a/zapzap/services/SystemThemeMonitor.py
+++ b/zapzap/services/SystemThemeMonitor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from enum import IntEnum
 from typing import Any
 from typing import cast
 
@@ -15,6 +16,15 @@ from PyQt6.QtGui import QStyleHints
 from PyQt6.QtWidgets import QApplication
 
 
+if not hasattr(Qt, "ColorScheme"):
+    class _ColorScheme(IntEnum):
+        Unknown = 0
+        Dark = 1
+        Light = 2
+
+    setattr(Qt, "ColorScheme", _ColorScheme)
+
+
 class SystemThemeMonitor(QObject):
     """Monitors system color scheme changes.
 
@@ -27,7 +37,7 @@ class SystemThemeMonitor(QObject):
     NAMESPACE = "org.freedesktop.appearance"
     KEY = "color-scheme"
 
-    color_scheme_changed = pyqtSignal(Qt.ColorScheme)
+    color_scheme_changed = pyqtSignal(object)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -191,6 +201,9 @@ class SystemThemeMonitor(QObject):
         if style_hints is None:
             return False
 
+        if not hasattr(style_hints, "colorSchemeChanged"):
+            return False
+
         style_hints.colorSchemeChanged.connect(
             self._qt_style_hints_color_scheme_changed
         )
@@ -219,6 +232,9 @@ class SystemThemeMonitor(QObject):
     def _qt_style_hints_get_current_color_scheme(cls) -> Qt.ColorScheme:
         style_hints = cls._qt_style_hints_get_style_hints()
         if not style_hints:
+            return Qt.ColorScheme.Unknown
+
+        if not hasattr(style_hints, "colorScheme"):
             return Qt.ColorScheme.Unknown
 
         color_scheme = style_hints.colorScheme()


### PR DESCRIPTION
### Motivation

- Standardize packaging build steps and artifact names for AppImage, Snap and DEB outputs to produce predictable release assets.
- Consolidate repeated installation and packaging logic into shared shell helpers to reduce duplication and improve reliability.
- Support Snap runtime detection and dictionary lookup in the application, and make system theme monitoring robust across Qt versions.

### Description

- Updated CI `release.yml` to normalize AnyLinux AppImage and `.zsync` artifact names, introduced a `build-snap` job to build and publish a Snap, and renamed DEB artifact names/outputs to a consistent `ZapZap-<version>-linux-<arch>` pattern and updated upload/release steps to match.`
- Added `builders/common/common.sh` with packaging utilities such as `build_wheel`, `install_wheel`, `project_version`, `install_dictionaries`, `validate_install`, and `prepare_package` and switched builders to use these helpers.
- Reworked AnyLinux builder scripts: `get-dependencies.sh` now sources `common.sh`, uses `prepare_package`, exports `DESTDIR`/`PREFIX`, and became executable; `make-appimage.sh` was simplified to use the prepared `AppDir` and validate the `zapzap` executable before creating the AppImage.
- Added Snap and DEB builder scripts and metadata: `builders/snap/snapcraft.yaml`, `builders/snap/build.sh`, and `builders/deb/build.sh`, which use the common helpers and produce normalized artifacts under `dist`.
- Application changes to support Snap packaging and runtime paths by adding `SNAP` to `Packaging` detection in `EnvironmentManager.py` and adding a `Packaging.SNAP` entry with sensible dictionary defaults in `PathManager.py`.
- Improved `SystemThemeMonitor.py` to handle environments where `Qt.ColorScheme` or `QStyleHints.colorSchemeChanged` are unavailable by providing a fallback enum and safe attribute checks, and changed the `color_scheme_changed` signal to a generic `object` to maintain compatibility.

### Testing

- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c68a2c0a4832b8eeeea5335a1fecf)