### PR TITLE
Fix adaptive settings component theming

### DIFF
--- a/zapzap/controllers/settings/notification_settings_controller.py
+++ b/zapzap/controllers/settings/notification_settings_controller.py
@@ -1,24 +1,61 @@
 from PyQt6.QtWidgets import QVBoxLayout, QWidget
 
+from zapzap.services.SettingsManager import SettingsManager
 from zapzap.views.pages.settings.notifications_settings_view import NotificationsSettingsView
 
 
 class NotificationSettingsController(QWidget):
-    """Classe responsável por gerenciar a página de notificações nas configurações."""
+    """Controller for notification settings persistence and signals."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self._setup_ui()
         self._initialize()
 
-    
     def _setup_ui(self):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         self.view = NotificationsSettingsView(self)
         layout.addWidget(self.view)
-    
+
     def _initialize(self):
-        """Inicializa a página carregando as configurações e configurando os sinais."""
-        #self._load_settings()
-        #self._connect_signals()
+        """Load saved settings and connect view signals."""
+        self._load_settings()
+        self._connect_signals()
+
+    def _load_settings(self):
+        self.view.notify_groupBox.checkbox.setChecked(
+            SettingsManager.get("notification/app", True)
+        )
+        self.view.show_photo.checkbox.setChecked(
+            SettingsManager.get("notification/show_photo", True)
+        )
+        self.view.show_name.checkbox.setChecked(
+            SettingsManager.get("notification/show_name", True)
+        )
+        self.view.show_msg.checkbox.setChecked(
+            SettingsManager.get("notification/show_msg", True)
+        )
+        self.view.donationMessage.checkbox.setChecked(
+            SettingsManager.get("notification/donation_message", False)
+        )
+
+    def _connect_signals(self):
+        self.view.notify_groupBox.checkbox.toggled.connect(
+            self._handle_toggle_notifications
+        )
+        self.view.show_photo.checkbox.toggled.connect(
+            lambda checked: SettingsManager.set("notification/show_photo", checked)
+        )
+        self.view.show_name.checkbox.toggled.connect(
+            lambda checked: SettingsManager.set("notification/show_name", checked)
+        )
+        self.view.show_msg.checkbox.toggled.connect(
+            lambda checked: SettingsManager.set("notification/show_msg", checked)
+        )
+        self.view.donationMessage.checkbox.toggled.connect(
+            lambda checked: SettingsManager.set("notification/donation_message", checked)
+        )
+
+    def _handle_toggle_notifications(self, is_enabled):
+        SettingsManager.set("notification/app", is_enabled)

--- a/zapzap/views/components/adaptive.py
+++ b/zapzap/views/components/adaptive.py
@@ -77,14 +77,19 @@ class AdaptiveStyleMixin:
             self._adaptive_theme_signal_connected = True
         self.apply_adaptive_style()
 
-    def _refresh_adaptive_style(self, next_theme=None):
+    def _refresh_adaptive_style(self, next_theme=None, *, force=False):
         next_theme = next_theme or theme_name(self)
         if next_theme != self._adaptive_theme:
             self._adaptive_theme = next_theme
-        self.apply_adaptive_style()
+            force = True
+        if force:
+            self.apply_adaptive_style()
 
     def _handle_theme_changed(self, _current_theme=None, effective_color_scheme=None):
-        self._refresh_adaptive_style(_theme_name_from_color_scheme(effective_color_scheme))
+        self._refresh_adaptive_style(
+            _theme_name_from_color_scheme(effective_color_scheme),
+            force=True,
+        )
 
     def eventFilter(self, watched, event):
         if watched is self and event.type() in self.WATCHED_EVENTS:

--- a/zapzap/views/components/adaptive.py
+++ b/zapzap/views/components/adaptive.py
@@ -1,6 +1,7 @@
 """Adaptive style primitives for ZapZap reusable components."""
 
 from PyQt6.QtCore import QEvent
+from PyQt6.QtCore import Qt
 from PyQt6.QtGui import QPalette
 
 from zapzap.services.ThemeManager import ThemeManager
@@ -33,8 +34,20 @@ DARK_TOKENS = {
 }
 
 
+def _theme_name_from_color_scheme(color_scheme):
+    if color_scheme == Qt.ColorScheme.Dark:
+        return "dark"
+    if color_scheme == Qt.ColorScheme.Light:
+        return "light"
+    return None
+
+
 def is_dark(widget):
-    """Return True when the current Qt palette is using a dark window color."""
+    """Return True when the component is using the dark theme."""
+    adaptive_theme = getattr(widget, "_adaptive_theme", None)
+    if adaptive_theme in {"dark", "light"}:
+        return adaptive_theme == "dark"
+
     return widget.palette().color(QPalette.ColorRole.Window).lightness() < 128
 
 
@@ -44,8 +57,9 @@ def theme_name(widget):
 
 
 def tokens(widget):
-    """Return ZapZap component tokens for the widget's current palette."""
+    """Return ZapZap component tokens for the widget's current theme."""
     return DARK_TOKENS if is_dark(widget) else LIGHT_TOKENS
+
 
 class AdaptiveStyleMixin:
     """Mixin that updates a component style when Qt emits palette changes."""
@@ -63,14 +77,14 @@ class AdaptiveStyleMixin:
             self._adaptive_theme_signal_connected = True
         self.apply_adaptive_style()
 
-    def _refresh_adaptive_style(self):
-        next_theme = theme_name(self)
+    def _refresh_adaptive_style(self, next_theme=None):
+        next_theme = next_theme or theme_name(self)
         if next_theme != self._adaptive_theme:
             self._adaptive_theme = next_theme
-            self.apply_adaptive_style()
+        self.apply_adaptive_style()
 
-    def _handle_theme_changed(self, *args):
-        self._refresh_adaptive_style()
+    def _handle_theme_changed(self, _current_theme=None, effective_color_scheme=None):
+        self._refresh_adaptive_style(_theme_name_from_color_scheme(effective_color_scheme))
 
     def eventFilter(self, watched, event):
         if watched is self and event.type() in self.WATCHED_EVENTS:


### PR DESCRIPTION
### Motivation
- Components must reapply their own styles when the app theme changes; current implementation could miss updates because it relied only on the widget palette and Qt events. 
- Notification settings controller needed to be restored to load/save settings and wire signals after the view was renamed/componentized.

### Description
- Update `zapzap/views/components/adaptive.py` to prefer an explicit component `_adaptive_theme` derived from `ThemeManager`'s `effective_color_scheme`, add `_theme_name_from_color_scheme`, and make `_handle_theme_changed` supply that theme so components reapply styles reliably; keep palette fallback for Qt events. 
- Change `is_dark`, `theme_name` and `tokens` to use the component adaptive theme when present so token selection (`LIGHT_TOKENS` / `DARK_TOKENS`) is consistent after theme changes. 
- Restore persistence and signal wiring in `zapzap/controllers/settings/notification_settings_controller.py` so the componentized `NotificationsSettingsView` loads `SettingsManager` keys and saves changes via the `SwitchRow.checkbox` signals.
- Files changed: `zapzap/views/components/adaptive.py`, `zapzap/controllers/settings/notification_settings_controller.py`.

### Testing
- Ran `python -m compileall zapzap/views/components zapzap/views/pages/settings/notifications_settings_view.py zapzap/controllers/settings/notification_settings_controller.py` and compilation succeeded. 
- Ran `git diff --check` with no issues reported. 
- Attempted an offscreen PyQt smoke test using `python - <<'PY' ...` to toggle `ThemeManager.set_theme(...)`, but the test could not run because `PyQt6` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a456b6f43e8832bb3170b1780686db3)