### PR TITLE
Add initial first-run setup dialog and integrate into startup flow

### DIFF
--- a/zapzap/app/application.py
+++ b/zapzap/app/application.py
@@ -3,6 +3,7 @@
 import sys
 
 import zapzap
+from PyQt6.QtCore import QTimer
 from PyQt6.QtCore import QUrl
 from PyQt6.QtGui import QDesktopServices
 
@@ -17,6 +18,7 @@ from zapzap.core.config.settings_manager import SettingsManager
 from zapzap.core.environment.setup_manager import SetupManager
 from zapzap.core.theme.theme_manager import ThemeManager
 from zapzap.core.i18n.translation_manager import TranslationManager
+from zapzap.features.initial_setup.controller import InitialSetupController
 
 
 def main():
@@ -65,13 +67,18 @@ def main():
         QDesktopServices.openUrl(QUrl(zapzap.__website__))
         SettingsManager.set("website/open_page", False)
 
+    should_show_initial_setup = InitialSetupController.should_show()
+
     if (
         SettingsManager.get("system/start_background",
                             False) or '--hideStart' in sys.argv
-    ):
+    ) and not should_show_initial_setup:
         main_window.hide()
     else:
         main_window.show()
+
+    if should_show_initial_setup:
+        QTimer.singleShot(0, lambda: InitialSetupController(main_window).exec())
 
     app.aboutToQuit.connect(ThemeManager.stop)
     app.aboutToQuit.connect(main_window.browser.shutdown)

--- a/zapzap/features/initial_setup/controller.py
+++ b/zapzap/features/initial_setup/controller.py
@@ -117,7 +117,7 @@ class InitialSetupController(InitialSetupView):
         if current_dictionary:
             self.dictionary_combo.setCurrentText(current_dictionary)
         has_dictionaries = bool(dictionaries)
-        self.dictionary_combo.setVisible(has_dictionaries)
+        self.dictionary_row.setVisible(has_dictionaries)
         self.dictionary_hint.setVisible(not has_dictionaries)
         if not has_dictionaries:
             self.spellcheck_enabled.setChecked(False)

--- a/zapzap/features/initial_setup/controller.py
+++ b/zapzap/features/initial_setup/controller.py
@@ -1,0 +1,205 @@
+"""Controller for the first-run initial setup dialog."""
+
+from __future__ import annotations
+
+from gettext import gettext as _
+
+from PyQt6.QtCore import QLocale
+
+from zapzap.core.i18n.translation_manager import TranslationManager
+from zapzap.core.theme.theme_manager import ThemeManager
+from zapzap.features.initial_setup.model import InitialSetupModel
+from zapzap.features.initial_setup.view import InitialSetupView
+
+
+class InitialSetupController(InitialSetupView):
+    """Coordinates onboarding state, navigation, and persistence."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.model = InitialSetupModel()
+        self.current_step = 0
+        self._load_settings()
+        self._connect_signals()
+        self.set_step(0)
+
+    @classmethod
+    def should_show(cls) -> bool:
+        return not InitialSetupModel.is_completed()
+
+    def _connect_signals(self):
+        self.btn_back.clicked.connect(self._previous_step)
+        self.btn_next.clicked.connect(self._next_step)
+        self.btn_finish.clicked.connect(self._finish)
+        self.btn_skip.clicked.connect(self._skip)
+        self.btn_download_path.clicked.connect(self._choose_download_path)
+        for index, button in enumerate(self.step_buttons):
+            button.clicked.connect(lambda _checked=False, step=index: self._go_to_step(step))
+        self.notifications_enabled.toggled.connect(self._sync_notification_controls)
+        self.tray_enabled.toggled.connect(self._sync_tray_controls)
+        self.spellcheck_enabled.toggled.connect(self._sync_dictionary_controls)
+
+    def _load_settings(self):
+        self._load_languages()
+        self._load_theme()
+        self.notifications_enabled.setChecked(
+            self.model.get_bool("notification/app", True)
+        )
+        self.notify_photo.setChecked(
+            self.model.get_bool("notification/show_photo", True)
+        )
+        self.notify_name.setChecked(
+            self.model.get_bool("notification/show_name", True)
+        )
+        self.notify_preview.setChecked(
+            self.model.get_bool("notification/show_msg", True)
+        )
+        self.tray_enabled.setChecked(self.model.get_bool("system/tray_icon", True))
+        self.tray_counter.setChecked(
+            self.model.get_bool("system/notificationCounter", False)
+        )
+        self.keep_background.setChecked(
+            not self.model.get_bool("system/quit_in_close", False)
+        )
+        self.confirm_close.setChecked(
+            self.model.get_bool("system/confirm_on_close", False)
+        )
+        self.start_system.setChecked(
+            self.model.get_bool("system/start_system", False)
+        )
+        self.start_minimized.setChecked(
+            self.model.get_bool("system/start_background", False)
+        )
+        self.download_path.setText(self.model.download_path())
+        self.spellcheck_enabled.setChecked(
+            self.model.get_bool("system/spellCheckers", True)
+        )
+        self._load_dictionaries()
+        self.permission_microphone.setChecked(
+            self.model.get_bool("permissions/auto_grant/microphone", False)
+        )
+        self.permission_camera.setChecked(
+            self.model.get_bool("permissions/auto_grant/camera", False)
+        )
+        self.permission_screen.setChecked(
+            self.model.get_bool("permissions/auto_grant/screen_contents", False)
+        )
+        self.webrtc_shield.setChecked(
+            self.model.get_bool("privacy/webrtc_shield", False)
+        )
+        self._sync_notification_controls()
+        self._sync_tray_controls()
+        self._sync_dictionary_controls()
+
+    def _load_languages(self):
+        self.language_combo.clear()
+        self.language_combo.addItem(_("System default"), TranslationManager.SYSTEM_LANGUAGE)
+        for language in self.model.available_languages():
+            self.language_combo.addItem(self._language_label(language), language)
+        current_language = self.model.current_language()
+        index = self.language_combo.findData(current_language)
+        self.language_combo.setCurrentIndex(index if index >= 0 else 0)
+
+    def _load_theme(self):
+        theme = self.model.current_theme()
+        theme_map = {
+            ThemeManager.Type.Auto.value: self.theme_auto,
+            ThemeManager.Type.Light.value: self.theme_light,
+            ThemeManager.Type.Dark.value: self.theme_dark,
+        }
+        theme_map.get(theme, self.theme_auto).setChecked(True)
+
+    def _load_dictionaries(self):
+        dictionaries = self.model.dictionaries()
+        self.dictionary_combo.clear()
+        self.dictionary_combo.addItems(dictionaries)
+        current_dictionary = self.model.current_dictionary()
+        if current_dictionary:
+            self.dictionary_combo.setCurrentText(current_dictionary)
+        has_dictionaries = bool(dictionaries)
+        self.dictionary_combo.setVisible(has_dictionaries)
+        self.dictionary_hint.setVisible(not has_dictionaries)
+        if not has_dictionaries:
+            self.spellcheck_enabled.setChecked(False)
+
+    def _language_label(self, language: str) -> str:
+        if language == TranslationManager.ENGLISH_LANGUAGE:
+            return f"{_('English')} - {language}"
+        locale = QLocale(language)
+        language_name = QLocale.languageToString(locale.language())
+        territory_name = QLocale.territoryToString(locale.territory())
+        if territory_name:
+            return f"{language_name} ({territory_name}) - {language}"
+        return f"{language_name} - {language}"
+
+    def _selected_theme(self) -> str:
+        if self.theme_light.isChecked():
+            return ThemeManager.Type.Light.value
+        if self.theme_dark.isChecked():
+            return ThemeManager.Type.Dark.value
+        return ThemeManager.Type.Auto.value
+
+    def _sync_notification_controls(self):
+        enabled = self.notifications_enabled.isChecked()
+        for checkbox in (self.notify_photo, self.notify_name, self.notify_preview):
+            checkbox.setEnabled(enabled)
+
+    def _sync_tray_controls(self):
+        enabled = self.tray_enabled.isChecked()
+        self.tray_counter.setEnabled(enabled)
+        if not enabled and self.keep_background.isChecked():
+            self.keep_background.setChecked(False)
+        self.keep_background.setEnabled(enabled)
+
+    def _sync_dictionary_controls(self):
+        enabled = self.spellcheck_enabled.isChecked() and self.dictionary_combo.count() > 0
+        self.dictionary_combo.setEnabled(enabled)
+
+    def _choose_download_path(self):
+        path = self.model.open_download_folder_dialog(self)
+        if path:
+            self.download_path.setText(path)
+
+    def _go_to_step(self, step: int):
+        if 0 <= step < self.pages.count():
+            self.current_step = step
+            self.set_step(self.current_step)
+
+    def _next_step(self):
+        self._go_to_step(self.current_step + 1)
+
+    def _previous_step(self):
+        self._go_to_step(self.current_step - 1)
+
+    def _skip(self):
+        self.model.mark_completed()
+        self.accept()
+
+    def _finish(self):
+        self._save_settings()
+        self.model.mark_completed()
+        self.accept()
+
+    def _save_settings(self):
+        self.model.set_language(self.language_combo.currentData())
+        self.model.set_theme(self._selected_theme())
+        self.model.set_bool("notification/app", self.notifications_enabled.isChecked())
+        self.model.set_bool("notification/show_photo", self.notify_photo.isChecked())
+        self.model.set_bool("notification/show_name", self.notify_name.isChecked())
+        self.model.set_bool("notification/show_msg", self.notify_preview.isChecked())
+        self.model.set_tray_icon(self.tray_enabled.isChecked())
+        self.model.set_bool("system/notificationCounter", self.tray_counter.isChecked())
+        self.model.refresh_tray()
+        self.model.set_bool("system/quit_in_close", not self.keep_background.isChecked())
+        self.model.set_bool("system/confirm_on_close", self.confirm_close.isChecked())
+        self.model.set_autostart(self.start_system.isChecked())
+        self.model.set_bool("system/start_background", self.start_minimized.isChecked())
+        if self.download_path.text():
+            self.model.set_download_path(self.download_path.text())
+        self.model.set_bool("system/spellCheckers", self.spellcheck_enabled.isChecked())
+        if self.spellcheck_enabled.isChecked() and self.dictionary_combo.currentText():
+            self.model.set_dictionary(self.dictionary_combo.currentText())
+        self.model.set_permission("microphone", self.permission_microphone.isChecked())
+        self.model.set_permission("camera", self.permission_camera.isChecked())
+        self.model.set_permission("screen_contents", self.permission_screen.isChecked())
+        self.model.set_bool("privacy/webrtc_shield", self.webrtc_shield.isChecked())

--- a/zapzap/features/initial_setup/model.py
+++ b/zapzap/features/initial_setup/model.py
@@ -1,0 +1,79 @@
+"""Persistence facade for the initial setup flow."""
+
+from __future__ import annotations
+
+from zapzap.core.config.settings_manager import SettingsManager
+from zapzap.core.i18n.translation_manager import TranslationManager
+from zapzap.core.theme.theme_manager import ThemeManager
+from zapzap.features.dictionaries.dictionaries_manager import DictionariesManager
+from zapzap.features.downloads.download_manager import DownloadManager
+from zapzap.features.permissions.permissions_manager import PermissionsManager
+from zapzap.features.startup.autostart_manager import AutostartManager
+from zapzap.features.tray.sys_tray_manager import SysTrayManager
+
+
+class InitialSetupModel:
+    """Centralizes settings read/write operations used by onboarding."""
+
+    COMPLETED_KEY = "onboarding/initial_setup_completed"
+
+    @classmethod
+    def is_completed(cls) -> bool:
+        return bool(SettingsManager.get(cls.COMPLETED_KEY, False))
+
+    @classmethod
+    def mark_completed(cls) -> None:
+        SettingsManager.set(cls.COMPLETED_KEY, True)
+
+    def available_languages(self) -> list[str]:
+        return TranslationManager.list_available_languages()
+
+    def current_language(self) -> str:
+        return TranslationManager.get_current_language()
+
+    def set_language(self, language: str) -> None:
+        TranslationManager.set_current_language(language)
+        TranslationManager.apply()
+
+    def current_theme(self) -> str:
+        return str(SettingsManager.get("system/theme", ThemeManager.Type.Auto.value))
+
+    def set_theme(self, theme: str) -> None:
+        ThemeManager.set_theme(theme)
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        return bool(SettingsManager.get(key, default))
+
+    def set_bool(self, key: str, value: bool) -> None:
+        SettingsManager.set(key, bool(value))
+
+    def set_autostart(self, enabled: bool) -> None:
+        SettingsManager.set("system/start_system", bool(enabled))
+        AutostartManager.create_desktop_file(bool(enabled))
+
+    def set_tray_icon(self, enabled: bool) -> None:
+        SysTrayManager.set_state(bool(enabled))
+
+    def refresh_tray(self) -> None:
+        SysTrayManager.refresh()
+
+    def download_path(self) -> str:
+        return DownloadManager.get_path()
+
+    def set_download_path(self, path: str) -> None:
+        DownloadManager.set_path(path)
+
+    def open_download_folder_dialog(self, parent) -> str:
+        return DownloadManager.open_folder_dialog(parent)
+
+    def dictionaries(self) -> list[str]:
+        return DictionariesManager.list()
+
+    def current_dictionary(self) -> str:
+        return DictionariesManager.get_current_dict()
+
+    def set_dictionary(self, language: str) -> None:
+        DictionariesManager.set_lang(language)
+
+    def set_permission(self, permission_id: str, enabled: bool) -> None:
+        PermissionsManager.set_auto_grant(permission_id, enabled)

--- a/zapzap/features/initial_setup/view.py
+++ b/zapzap/features/initial_setup/view.py
@@ -190,7 +190,7 @@ class InitialSetupView(QDialog):
         card = self._card(page, layout)
         card.addWidget(QLabel(_("Download directory")))
         path_row = QHBoxLayout()
-        self.download_path = LineEdit(page)
+        self.download_path = LineEdit(parent=page)
         self.download_path.setReadOnly(True)
         self.btn_download_path = Button(_("Choose folder"), parent=page)
         path_row.addWidget(self.download_path, 1)

--- a/zapzap/features/initial_setup/view.py
+++ b/zapzap/features/initial_setup/view.py
@@ -116,6 +116,7 @@ class InitialSetupView(QDialog):
         self.language_row = SettingsSelectRow(
             _("Interface language"),
             _("The interface language is applied when you finish setup."),
+            [""]
         )
         self.language_combo = self.language_row.combo
         language_card.add_row(self.language_row)

--- a/zapzap/features/initial_setup/view.py
+++ b/zapzap/features/initial_setup/view.py
@@ -1,0 +1,272 @@
+"""Initial setup dialog view."""
+
+from __future__ import annotations
+
+from gettext import gettext as _
+
+from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import QButtonGroup
+from PyQt6.QtWidgets import QDialog
+from PyQt6.QtWidgets import QFrame
+from PyQt6.QtWidgets import QHBoxLayout
+from PyQt6.QtWidgets import QLabel
+from PyQt6.QtWidgets import QPushButton
+from PyQt6.QtWidgets import QStackedWidget
+from PyQt6.QtWidgets import QVBoxLayout
+from PyQt6.QtWidgets import QWidget
+
+from zapzap.ui.components import Button
+from zapzap.ui.components import CheckBox
+from zapzap.ui.components import ComboBox
+from zapzap.ui.components import LineEdit
+from zapzap.ui.components import RadioButton
+
+
+class InitialSetupView(QDialog):
+    """Guided first-run setup dialog."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("InitialSetupDialog")
+        self.setWindowTitle(_("Set up ZapZap"))
+        self.setModal(True)
+        self.setMinimumSize(860, 620)
+        self.step_buttons = []
+        self._setup_ui()
+        self._apply_style()
+
+    def _setup_ui(self):
+        root = QVBoxLayout(self)
+        root.setContentsMargins(0, 0, 0, 0)
+        root.setSpacing(0)
+
+        content = QHBoxLayout()
+        content.setContentsMargins(0, 0, 0, 0)
+        content.setSpacing(0)
+        root.addLayout(content, 1)
+
+        self.sidebar = QFrame(self)
+        self.sidebar.setObjectName("InitialSetupSidebar")
+        self.sidebar_layout = QVBoxLayout(self.sidebar)
+        self.sidebar_layout.setContentsMargins(22, 24, 22, 24)
+        self.sidebar_layout.setSpacing(8)
+        title = QLabel(_("Welcome to ZapZap"), self.sidebar)
+        title.setObjectName("InitialSetupTitle")
+        subtitle = QLabel(_("Choose the essentials now. You can change everything later in Settings."), self.sidebar)
+        subtitle.setObjectName("InitialSetupSubtitle")
+        subtitle.setWordWrap(True)
+        self.sidebar_layout.addWidget(title)
+        self.sidebar_layout.addWidget(subtitle)
+        self.sidebar_layout.addSpacing(16)
+        content.addWidget(self.sidebar, 0)
+
+        self.pages = QStackedWidget(self)
+        content.addWidget(self.pages, 1)
+
+        self._add_page(self._appearance_page(), _("Basics"))
+        self._add_page(self._notifications_page(), _("Notifications"))
+        self._add_page(self._background_page(), _("Background"))
+        self._add_page(self._files_page(), _("Files"))
+        self._add_page(self._permissions_page(), _("Permissions"))
+        self._add_page(self._finish_page(), _("Finish"))
+        self.sidebar_layout.addStretch(1)
+
+        footer = QFrame(self)
+        footer.setObjectName("InitialSetupFooter")
+        footer_layout = QHBoxLayout(footer)
+        footer_layout.setContentsMargins(18, 12, 18, 12)
+        self.btn_skip = Button(_("Skip setup"), parent=footer)
+        self.btn_back = Button(_("Back"), parent=footer)
+        self.btn_next = Button(_("Next"), parent=footer)
+        self.btn_finish = Button(_("Finish"), parent=footer)
+        footer_layout.addWidget(self.btn_skip)
+        footer_layout.addStretch(1)
+        footer_layout.addWidget(self.btn_back)
+        footer_layout.addWidget(self.btn_next)
+        footer_layout.addWidget(self.btn_finish)
+        root.addWidget(footer)
+
+    def _add_page(self, page: QWidget, label: str):
+        index = self.pages.addWidget(page)
+        button = QPushButton(f"{index + 1}. {label}", self.sidebar)
+        button.setObjectName("InitialSetupStepButton")
+        self.step_buttons.append(button)
+        self.sidebar_layout.addWidget(button)
+
+    def _page(self, title: str, description: str) -> tuple[QWidget, QVBoxLayout]:
+        page = QWidget(self)
+        layout = QVBoxLayout(page)
+        layout.setContentsMargins(34, 30, 34, 24)
+        layout.setSpacing(14)
+        title_label = QLabel(title, page)
+        title_label.setObjectName("InitialSetupPageTitle")
+        description_label = QLabel(description, page)
+        description_label.setObjectName("InitialSetupPageDescription")
+        description_label.setWordWrap(True)
+        layout.addWidget(title_label)
+        layout.addWidget(description_label)
+        layout.addSpacing(10)
+        return page, layout
+
+    def _card(self, parent, layout):
+        card = QFrame(parent)
+        card.setObjectName("InitialSetupCard")
+        card_layout = QVBoxLayout(card)
+        card_layout.setContentsMargins(18, 16, 18, 16)
+        card_layout.setSpacing(10)
+        layout.addWidget(card)
+        return card_layout
+
+    def _appearance_page(self):
+        page, layout = self._page(
+            _("Language and appearance"),
+            _("Start with the interface language and a comfortable visual theme."),
+        )
+        card = self._card(page, layout)
+        card.addWidget(QLabel(_("Interface language")))
+        self.language_combo = ComboBox(page)
+        card.addWidget(self.language_combo)
+        card.addSpacing(10)
+        card.addWidget(QLabel(_("Theme")))
+        self.theme_group = QButtonGroup(page)
+        self.theme_auto = RadioButton(_("Automatic"), page)
+        self.theme_light = RadioButton(_("Light"), page)
+        self.theme_dark = RadioButton(_("Dark"), page)
+        for button in (self.theme_auto, self.theme_light, self.theme_dark):
+            self.theme_group.addButton(button)
+            card.addWidget(button)
+        layout.addStretch(1)
+        return page
+
+    def _notifications_page(self):
+        page, layout = self._page(
+            _("Notifications and privacy"),
+            _("Decide how much message information appears in native notification banners."),
+        )
+        card = self._card(page, layout)
+        self.notifications_enabled = CheckBox(_("Enable desktop notifications"), page)
+        self.notify_photo = CheckBox(_("Show contact photo"), page)
+        self.notify_name = CheckBox(_("Show contact or group name"), page)
+        self.notify_preview = CheckBox(_("Show message preview"), page)
+        for checkbox in (
+            self.notifications_enabled,
+            self.notify_photo,
+            self.notify_name,
+            self.notify_preview,
+        ):
+            card.addWidget(checkbox)
+        layout.addStretch(1)
+        return page
+
+    def _background_page(self):
+        page, layout = self._page(
+            _("Background behavior"),
+            _("Choose whether ZapZap should stay available from the tray and start with your session."),
+        )
+        card = self._card(page, layout)
+        self.tray_enabled = CheckBox(_("Show icon in the system tray"), page)
+        self.tray_counter = CheckBox(_("Show unread counter on the tray icon"), page)
+        self.keep_background = CheckBox(_("Keep running in the background when closing the window"), page)
+        self.confirm_close = CheckBox(_("Ask for confirmation before closing"), page)
+        self.start_system = CheckBox(_("Start with the system"), page)
+        self.start_minimized = CheckBox(_("Start minimized"), page)
+        for checkbox in (
+            self.tray_enabled,
+            self.tray_counter,
+            self.keep_background,
+            self.confirm_close,
+            self.start_system,
+            self.start_minimized,
+        ):
+            card.addWidget(checkbox)
+        layout.addStretch(1)
+        return page
+
+    def _files_page(self):
+        page, layout = self._page(
+            _("Downloads and typing"),
+            _("Choose where files are saved and enable spell checking when dictionaries are available."),
+        )
+        card = self._card(page, layout)
+        card.addWidget(QLabel(_("Download directory")))
+        path_row = QHBoxLayout()
+        self.download_path = LineEdit(page)
+        self.download_path.setReadOnly(True)
+        self.btn_download_path = Button(_("Choose folder"), parent=page)
+        path_row.addWidget(self.download_path, 1)
+        path_row.addWidget(self.btn_download_path)
+        card.addLayout(path_row)
+        self.spellcheck_enabled = CheckBox(_("Enable spell checker"), page)
+        card.addWidget(self.spellcheck_enabled)
+        card.addWidget(QLabel(_("Dictionary language")))
+        self.dictionary_combo = ComboBox(page)
+        card.addWidget(self.dictionary_combo)
+        self.dictionary_hint = QLabel(_("No compiled dictionaries were found. You can configure dictionaries later in Settings."), page)
+        self.dictionary_hint.setObjectName("InitialSetupHint")
+        self.dictionary_hint.setWordWrap(True)
+        card.addWidget(self.dictionary_hint)
+        layout.addStretch(1)
+        return page
+
+    def _permissions_page(self):
+        page, layout = self._page(
+            _("Essential permissions"),
+            _("Allow only the WhatsApp Web permissions you want to grant automatically."),
+        )
+        card = self._card(page, layout)
+        self.permission_microphone = CheckBox(_("Microphone"), page)
+        self.permission_camera = CheckBox(_("Camera"), page)
+        self.permission_screen = CheckBox(_("Screen sharing"), page)
+        self.webrtc_shield = CheckBox(_("Reduce WebRTC IP exposure"), page)
+        for checkbox in (
+            self.permission_microphone,
+            self.permission_camera,
+            self.permission_screen,
+            self.webrtc_shield,
+        ):
+            card.addWidget(checkbox)
+        hint = QLabel(_("When a permission is off, ZapZap will ask again when WhatsApp Web requests it."), page)
+        hint.setObjectName("InitialSetupHint")
+        hint.setWordWrap(True)
+        card.addWidget(hint)
+        layout.addStretch(1)
+        return page
+
+    def _finish_page(self):
+        page, layout = self._page(
+            _("You're ready"),
+            _("ZapZap will save these preferences now. Advanced options like proxy, custom CSS/JavaScript, Flatpak permissions, and performance tweaks remain available in Settings."),
+        )
+        card = self._card(page, layout)
+        done = QLabel(_("You can revisit all choices from Settings at any time."), page)
+        done.setObjectName("InitialSetupCompletion")
+        done.setWordWrap(True)
+        card.addWidget(done)
+        layout.addStretch(1)
+        return page
+
+    def _apply_style(self):
+        self.setStyleSheet("""
+            QDialog#InitialSetupDialog { background: palette(window); color: palette(text); }
+            QFrame#InitialSetupSidebar { background: palette(base); border-right: 1px solid palette(mid); min-width: 230px; max-width: 280px; }
+            QLabel#InitialSetupTitle { font-size: 22px; font-weight: 800; }
+            QLabel#InitialSetupSubtitle, QLabel#InitialSetupPageDescription, QLabel#InitialSetupHint { color: palette(placeholder-text); }
+            QLabel#InitialSetupPageTitle { font-size: 24px; font-weight: 800; }
+            QFrame#InitialSetupCard { background: palette(base); border: 1px solid palette(mid); border-radius: 16px; }
+            QFrame#InitialSetupFooter { background: palette(base); border-top: 1px solid palette(mid); }
+            QPushButton#InitialSetupStepButton { border: 0; border-radius: 10px; padding: 10px 12px; text-align: left; background: transparent; color: palette(text); }
+            QPushButton#InitialSetupStepButton:hover { background: palette(alternate-base); }
+            QPushButton#InitialSetupStepButton[active="true"] { background: palette(alternate-base); color: palette(highlight); font-weight: 700; }
+            QLabel#InitialSetupCompletion { font-size: 16px; font-weight: 600; }
+        """)
+
+    def set_step(self, index: int):
+        self.pages.setCurrentIndex(index)
+        for button_index, button in enumerate(self.step_buttons):
+            button.setProperty("active", button_index == index)
+            button.style().unpolish(button)
+            button.style().polish(button)
+        self.btn_back.setEnabled(index > 0)
+        last_page = index == self.pages.count() - 1
+        self.btn_next.setVisible(not last_page)
+        self.btn_finish.setVisible(last_page)

--- a/zapzap/features/initial_setup/view.py
+++ b/zapzap/features/initial_setup/view.py
@@ -108,14 +108,14 @@ class InitialSetupView(QDialog):
         )
 
         language_section = SettingsSection(
-            _("Language"),
-            _("Choose the interface language used by ZapZap."),
+            _("Interface language"),
+            "",
             page,
         )
         language_card = SettingsCard(page)
         self.language_row = SettingsSelectRow(
             _("Interface language"),
-            _("The interface language is applied when you finish setup."),
+            "",
         )
         self.language_combo = self.language_row.combo
         language_card.add_row(self.language_row)
@@ -124,7 +124,7 @@ class InitialSetupView(QDialog):
 
         theme_section = SettingsSection(
             _("Theme"),
-            _("Choose the visual theme."),
+            "",
             page,
         )
         self.theme_group = QButtonGroup(page)
@@ -152,14 +152,14 @@ class InitialSetupView(QDialog):
             self,
         )
         desktop_section = SettingsSection(
-            _("Desktop notifications"),
-            _("Choose whether ZapZap may show desktop notifications."),
+            _("Notifications"),
+            "",
             page,
         )
         desktop_card = SettingsCard(page)
         self.notifications_enabled_row = SettingsSwitchRow(
-            _("Enable notifications"),
-            _("Allow ZapZap to publish native desktop notifications for WhatsApp activity."),
+            _("Enable desktop notifications"),
+            "",
         )
         self.notifications_enabled = self.notifications_enabled_row.checkbox
         desktop_card.add_row(self.notifications_enabled_row)
@@ -167,22 +167,22 @@ class InitialSetupView(QDialog):
         page.add_section(desktop_section)
 
         privacy_section = SettingsSection(
-            _("Notification privacy"),
-            _("Limit what is visible in notification banners."),
+            _("Notifications and privacy"),
+            "",
             page,
         )
         privacy_card = SettingsCard(page)
         self.notify_photo_row = SettingsSwitchRow(
             _("Show contact photo"),
-            _("Display the sender avatar when it is available."),
+            "",
         )
         self.notify_name_row = SettingsSwitchRow(
-            _("Show contact name"),
-            _("Display the sender or group name."),
+            _("Show contact or group name"),
+            "",
         )
         self.notify_preview_row = SettingsSwitchRow(
             _("Show message preview"),
-            _("Display the message text in the notification."),
+            "",
         )
         self.notify_photo = self.notify_photo_row.checkbox
         self.notify_name = self.notify_name_row.checkbox
@@ -201,18 +201,18 @@ class InitialSetupView(QDialog):
             self,
         )
         tray_section = SettingsSection(
-            _("Tray icon"),
-            _("Control tray icon visibility and unread counter."),
+            _("Background behavior"),
+            "",
             page,
         )
         tray_card = SettingsCard(page)
         self.tray_enabled_row = SettingsSwitchRow(
-            _("Enable tray icon"),
-            _("Show ZapZap in the system tray."),
+            _("Show icon in the system tray"),
+            "",
         )
         self.tray_counter_row = SettingsSwitchRow(
-            _("Notification counter"),
-            _("Show unread notifications on the tray icon."),
+            _("Show unread counter on the tray icon"),
+            "",
         )
         self.tray_enabled = self.tray_enabled_row.checkbox
         self.tray_counter = self.tray_counter_row.checkbox
@@ -222,18 +222,18 @@ class InitialSetupView(QDialog):
         page.add_section(tray_section)
 
         window_section = SettingsSection(
-            _("Window behavior"),
-            _("Configure close behavior."),
+            _("Background behavior"),
+            "",
             page,
         )
         window_card = SettingsCard(page)
         self.keep_background_row = SettingsSwitchRow(
-            _("Keep running in the background"),
-            _("Hide the main window instead of quitting when it is closed."),
+            _("Keep running in the background when closing the window"),
+            "",
         )
         self.confirm_close_row = SettingsSwitchRow(
-            _("Confirm before closing the window"),
-            _("Ask for confirmation before closing ZapZap."),
+            _("Ask for confirmation before closing"),
+            "",
         )
         self.keep_background = self.keep_background_row.checkbox
         self.confirm_close = self.confirm_close_row.checkbox
@@ -243,18 +243,18 @@ class InitialSetupView(QDialog):
         page.add_section(window_section)
 
         startup_section = SettingsSection(
-            _("Startup"),
-            _("Control how ZapZap behaves when your desktop session starts."),
+            _("Background behavior"),
+            "",
             page,
         )
         startup_card = SettingsCard(page)
         self.start_system_row = SettingsSwitchRow(
             _("Start with the system"),
-            _("Create or remove the desktop autostart entry."),
+            "",
         )
         self.start_minimized_row = SettingsSwitchRow(
             _("Start minimized"),
-            _("Open ZapZap in the background instead of showing the main window."),
+            "",
         )
         self.start_system = self.start_system_row.checkbox
         self.start_minimized = self.start_minimized_row.checkbox
@@ -272,14 +272,14 @@ class InitialSetupView(QDialog):
             self,
         )
         downloads_section = SettingsSection(
-            _("Downloads"),
-            _("Choose where downloaded files are saved."),
+            _("Download directory"),
+            "",
             page,
         )
         downloads_card = SettingsCard(page)
         self.download_path_row = SettingsPathRow(
             _("Download directory"),
-            _("Set a custom folder or keep the current download location."),
+            "",
             button_text=_("Choose folder"),
         )
         self.download_path = self.download_path_row.line_edit
@@ -290,18 +290,18 @@ class InitialSetupView(QDialog):
         page.add_section(downloads_section)
 
         spell_section = SettingsSection(
-            _("Spell checker"),
-            _("Select compiled dictionaries and where ZapZap should look for them."),
+            _("Downloads and typing"),
+            "",
             page,
         )
         spell_card = SettingsCard(page)
         self.spellcheck_enabled_row = SettingsSwitchRow(
             _("Enable spell checker"),
-            _("Use Qt WebEngine spell checking with the selected dictionary."),
+            "",
         )
         self.dictionary_row = SettingsSelectRow(
             _("Dictionary language"),
-            _("Recognizes only compiled dictionaries (.bdic)."),
+            "",
         )
         self.dictionary_hint = SettingsInfoBox(
             _("No compiled dictionaries were found. You can configure dictionaries later in Settings."),
@@ -324,31 +324,31 @@ class InitialSetupView(QDialog):
             self,
         )
         section = SettingsSection(
-            _("Permissions"),
-            _("When an option is unchecked, ZapZap will ask again in each session."),
+            _("Essential permissions"),
+            "",
             page,
         )
         card = SettingsCard(page)
         card.add_row(
             SettingsInfoBox(
-                _("Enable only the permissions you want to grant automatically when the page requests them."),
+                _("When a permission is off, ZapZap will ask again when WhatsApp Web requests it."),
             )
         )
         self.permission_microphone_row = SettingsSwitchRow(
             _("Microphone"),
-            _("Automatically allow access to your microphone."),
+            "",
         )
         self.permission_camera_row = SettingsSwitchRow(
             _("Camera"),
-            _("Automatically allow access to your camera."),
+            "",
         )
         self.permission_screen_row = SettingsSwitchRow(
-            _("Screen contents"),
-            _("Automatically allow sharing of screen contents."),
+            _("Screen sharing"),
+            "",
         )
         self.webrtc_shield_row = SettingsSwitchRow(
-            _("WebRTC shield"),
-            _("Reduce WebRTC IP exposure."),
+            _("Reduce WebRTC IP exposure"),
+            "",
         )
         self.permission_microphone = self.permission_microphone_row.checkbox
         self.permission_camera = self.permission_camera_row.checkbox
@@ -369,18 +369,18 @@ class InitialSetupView(QDialog):
     def _finish_page(self):
         page = SettingsPage(
             _("You're ready"),
-            _("ZapZap will save these preferences now. Advanced options remain available in Settings."),
+            _("ZapZap will save these preferences now. Advanced options like proxy, custom CSS/JavaScript, Flatpak permissions, and performance tweaks remain available in Settings."),
             self,
         )
         section = SettingsSection(
-            _("Finish setup"),
-            _("Review advanced options later whenever you need them."),
+            _("You're ready"),
+            "",
             page,
         )
         card = SettingsCard(page)
         card.add_row(
             SettingsInfoBox(
-                _("You can revisit all choices from Settings at any time. Proxy, custom CSS/JavaScript, Flatpak permissions, and performance tweaks are still available there."),
+                _("You can revisit all choices from Settings at any time."),
                 "success",
             )
         )

--- a/zapzap/features/initial_setup/view.py
+++ b/zapzap/features/initial_setup/view.py
@@ -108,14 +108,14 @@ class InitialSetupView(QDialog):
         )
 
         language_section = SettingsSection(
-            _("Interface language"),
-            "",
+            _("Language"),
+            _("Choose the interface language used by ZapZap."),
             page,
         )
         language_card = SettingsCard(page)
         self.language_row = SettingsSelectRow(
             _("Interface language"),
-            "",
+            _("The interface language is applied when you finish setup."),
         )
         self.language_combo = self.language_row.combo
         language_card.add_row(self.language_row)
@@ -124,7 +124,7 @@ class InitialSetupView(QDialog):
 
         theme_section = SettingsSection(
             _("Theme"),
-            "",
+            _("Choose the visual theme."),
             page,
         )
         self.theme_group = QButtonGroup(page)
@@ -152,14 +152,14 @@ class InitialSetupView(QDialog):
             self,
         )
         desktop_section = SettingsSection(
-            _("Notifications"),
-            "",
+            _("Desktop notifications"),
+            _("Choose whether ZapZap may show desktop notifications."),
             page,
         )
         desktop_card = SettingsCard(page)
         self.notifications_enabled_row = SettingsSwitchRow(
-            _("Enable desktop notifications"),
-            "",
+            _("Enable notifications"),
+            _("Allow ZapZap to publish native desktop notifications for WhatsApp activity."),
         )
         self.notifications_enabled = self.notifications_enabled_row.checkbox
         desktop_card.add_row(self.notifications_enabled_row)
@@ -167,22 +167,22 @@ class InitialSetupView(QDialog):
         page.add_section(desktop_section)
 
         privacy_section = SettingsSection(
-            _("Notifications and privacy"),
-            "",
+            _("Notification privacy"),
+            _("Limit what is visible in notification banners."),
             page,
         )
         privacy_card = SettingsCard(page)
         self.notify_photo_row = SettingsSwitchRow(
             _("Show contact photo"),
-            "",
+            _("Display the sender avatar when it is available."),
         )
         self.notify_name_row = SettingsSwitchRow(
-            _("Show contact or group name"),
-            "",
+            _("Show contact name"),
+            _("Display the sender or group name."),
         )
         self.notify_preview_row = SettingsSwitchRow(
             _("Show message preview"),
-            "",
+            _("Display the message text in the notification."),
         )
         self.notify_photo = self.notify_photo_row.checkbox
         self.notify_name = self.notify_name_row.checkbox
@@ -201,18 +201,18 @@ class InitialSetupView(QDialog):
             self,
         )
         tray_section = SettingsSection(
-            _("Background behavior"),
-            "",
+            _("Tray icon"),
+            _("Control tray icon visibility and unread counter."),
             page,
         )
         tray_card = SettingsCard(page)
         self.tray_enabled_row = SettingsSwitchRow(
-            _("Show icon in the system tray"),
-            "",
+            _("Enable tray icon"),
+            _("Show ZapZap in the system tray."),
         )
         self.tray_counter_row = SettingsSwitchRow(
-            _("Show unread counter on the tray icon"),
-            "",
+            _("Notification counter"),
+            _("Show unread notifications on the tray icon."),
         )
         self.tray_enabled = self.tray_enabled_row.checkbox
         self.tray_counter = self.tray_counter_row.checkbox
@@ -222,18 +222,18 @@ class InitialSetupView(QDialog):
         page.add_section(tray_section)
 
         window_section = SettingsSection(
-            _("Background behavior"),
-            "",
+            _("Window behavior"),
+            _("Configure close behavior."),
             page,
         )
         window_card = SettingsCard(page)
         self.keep_background_row = SettingsSwitchRow(
-            _("Keep running in the background when closing the window"),
-            "",
+            _("Keep running in the background"),
+            _("Hide the main window instead of quitting when it is closed."),
         )
         self.confirm_close_row = SettingsSwitchRow(
-            _("Ask for confirmation before closing"),
-            "",
+            _("Confirm before closing the window"),
+            _("Ask for confirmation before closing ZapZap."),
         )
         self.keep_background = self.keep_background_row.checkbox
         self.confirm_close = self.confirm_close_row.checkbox
@@ -243,18 +243,18 @@ class InitialSetupView(QDialog):
         page.add_section(window_section)
 
         startup_section = SettingsSection(
-            _("Background behavior"),
-            "",
+            _("Startup"),
+            _("Control how ZapZap behaves when your desktop session starts."),
             page,
         )
         startup_card = SettingsCard(page)
         self.start_system_row = SettingsSwitchRow(
             _("Start with the system"),
-            "",
+            _("Create or remove the desktop autostart entry."),
         )
         self.start_minimized_row = SettingsSwitchRow(
             _("Start minimized"),
-            "",
+            _("Open ZapZap in the background instead of showing the main window."),
         )
         self.start_system = self.start_system_row.checkbox
         self.start_minimized = self.start_minimized_row.checkbox
@@ -272,14 +272,14 @@ class InitialSetupView(QDialog):
             self,
         )
         downloads_section = SettingsSection(
-            _("Download directory"),
-            "",
+            _("Downloads"),
+            _("Choose where downloaded files are saved."),
             page,
         )
         downloads_card = SettingsCard(page)
         self.download_path_row = SettingsPathRow(
             _("Download directory"),
-            "",
+            _("Set a custom folder or keep the current download location."),
             button_text=_("Choose folder"),
         )
         self.download_path = self.download_path_row.line_edit
@@ -290,18 +290,18 @@ class InitialSetupView(QDialog):
         page.add_section(downloads_section)
 
         spell_section = SettingsSection(
-            _("Downloads and typing"),
-            "",
+            _("Spell checker"),
+            _("Select compiled dictionaries and where ZapZap should look for them."),
             page,
         )
         spell_card = SettingsCard(page)
         self.spellcheck_enabled_row = SettingsSwitchRow(
             _("Enable spell checker"),
-            "",
+            _("Use Qt WebEngine spell checking with the selected dictionary."),
         )
         self.dictionary_row = SettingsSelectRow(
             _("Dictionary language"),
-            "",
+            _("Recognizes only compiled dictionaries (.bdic)."),
         )
         self.dictionary_hint = SettingsInfoBox(
             _("No compiled dictionaries were found. You can configure dictionaries later in Settings."),
@@ -324,31 +324,31 @@ class InitialSetupView(QDialog):
             self,
         )
         section = SettingsSection(
-            _("Essential permissions"),
-            "",
+            _("Permissions"),
+            _("When an option is unchecked, ZapZap will ask again in each session."),
             page,
         )
         card = SettingsCard(page)
         card.add_row(
             SettingsInfoBox(
-                _("When a permission is off, ZapZap will ask again when WhatsApp Web requests it."),
+                _("Enable only the permissions you want to grant automatically when the page requests them."),
             )
         )
         self.permission_microphone_row = SettingsSwitchRow(
             _("Microphone"),
-            "",
+            _("Automatically allow access to your microphone."),
         )
         self.permission_camera_row = SettingsSwitchRow(
             _("Camera"),
-            "",
+            _("Automatically allow access to your camera."),
         )
         self.permission_screen_row = SettingsSwitchRow(
-            _("Screen sharing"),
-            "",
+            _("Screen contents"),
+            _("Automatically allow sharing of screen contents."),
         )
         self.webrtc_shield_row = SettingsSwitchRow(
-            _("Reduce WebRTC IP exposure"),
-            "",
+            _("WebRTC shield"),
+            _("Reduce WebRTC IP exposure."),
         )
         self.permission_microphone = self.permission_microphone_row.checkbox
         self.permission_camera = self.permission_camera_row.checkbox
@@ -369,18 +369,18 @@ class InitialSetupView(QDialog):
     def _finish_page(self):
         page = SettingsPage(
             _("You're ready"),
-            _("ZapZap will save these preferences now. Advanced options like proxy, custom CSS/JavaScript, Flatpak permissions, and performance tweaks remain available in Settings."),
+            _("ZapZap will save these preferences now. Advanced options remain available in Settings."),
             self,
         )
         section = SettingsSection(
-            _("You're ready"),
-            "",
+            _("Finish setup"),
+            _("Review advanced options later whenever you need them."),
             page,
         )
         card = SettingsCard(page)
         card.add_row(
             SettingsInfoBox(
-                _("You can revisit all choices from Settings at any time."),
+                _("You can revisit all choices from Settings at any time. Proxy, custom CSS/JavaScript, Flatpak permissions, and performance tweaks are still available there."),
                 "success",
             )
         )

--- a/zapzap/features/initial_setup/view.py
+++ b/zapzap/features/initial_setup/view.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from gettext import gettext as _
 
-from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QButtonGroup
 from PyQt6.QtWidgets import QDialog
 from PyQt6.QtWidgets import QFrame
@@ -15,22 +14,27 @@ from PyQt6.QtWidgets import QStackedWidget
 from PyQt6.QtWidgets import QVBoxLayout
 from PyQt6.QtWidgets import QWidget
 
+from zapzap.features.settings.components import SettingsCard
+from zapzap.features.settings.components import SettingsInfoBox
+from zapzap.features.settings.components import SettingsPage
+from zapzap.features.settings.components import SettingsPathRow
+from zapzap.features.settings.components import SettingsRadioGroup
+from zapzap.features.settings.components import SettingsSection
+from zapzap.features.settings.components import SettingsSelectRow
+from zapzap.features.settings.components import SettingsSwitchRow
 from zapzap.ui.components import Button
-from zapzap.ui.components import CheckBox
-from zapzap.ui.components import ComboBox
-from zapzap.ui.components import LineEdit
 from zapzap.ui.components import RadioButton
 
 
 class InitialSetupView(QDialog):
-    """Guided first-run setup dialog."""
+    """Guided first-run setup dialog using the settings visual language."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setObjectName("InitialSetupDialog")
         self.setWindowTitle(_("Set up ZapZap"))
         self.setModal(True)
-        self.setMinimumSize(860, 620)
+        self.setMinimumSize(900, 640)
         self.step_buttons = []
         self._setup_ui()
         self._apply_style()
@@ -52,7 +56,10 @@ class InitialSetupView(QDialog):
         self.sidebar_layout.setSpacing(8)
         title = QLabel(_("Welcome to ZapZap"), self.sidebar)
         title.setObjectName("InitialSetupTitle")
-        subtitle = QLabel(_("Choose the essentials now. You can change everything later in Settings."), self.sidebar)
+        subtitle = QLabel(
+            _("Choose the essentials now. You can change everything later in Settings."),
+            self.sidebar,
+        )
         subtitle.setObjectName("InitialSetupSubtitle")
         subtitle.setWordWrap(True)
         self.sidebar_layout.addWidget(title)
@@ -93,171 +100,334 @@ class InitialSetupView(QDialog):
         self.step_buttons.append(button)
         self.sidebar_layout.addWidget(button)
 
-    def _page(self, title: str, description: str) -> tuple[QWidget, QVBoxLayout]:
-        page = QWidget(self)
-        layout = QVBoxLayout(page)
-        layout.setContentsMargins(34, 30, 34, 24)
-        layout.setSpacing(14)
-        title_label = QLabel(title, page)
-        title_label.setObjectName("InitialSetupPageTitle")
-        description_label = QLabel(description, page)
-        description_label.setObjectName("InitialSetupPageDescription")
-        description_label.setWordWrap(True)
-        layout.addWidget(title_label)
-        layout.addWidget(description_label)
-        layout.addSpacing(10)
-        return page, layout
-
-    def _card(self, parent, layout):
-        card = QFrame(parent)
-        card.setObjectName("InitialSetupCard")
-        card_layout = QVBoxLayout(card)
-        card_layout.setContentsMargins(18, 16, 18, 16)
-        card_layout.setSpacing(10)
-        layout.addWidget(card)
-        return card_layout
-
     def _appearance_page(self):
-        page, layout = self._page(
+        page = SettingsPage(
             _("Language and appearance"),
             _("Start with the interface language and a comfortable visual theme."),
+            self,
         )
-        card = self._card(page, layout)
-        card.addWidget(QLabel(_("Interface language")))
-        self.language_combo = ComboBox(page)
-        card.addWidget(self.language_combo)
-        card.addSpacing(10)
-        card.addWidget(QLabel(_("Theme")))
+
+        language_section = SettingsSection(
+            _("Language"),
+            _("Choose the interface language used by ZapZap."),
+            page,
+        )
+        language_card = SettingsCard(page)
+        self.language_row = SettingsSelectRow(
+            _("Interface language"),
+            _("The interface language is applied when you finish setup."),
+        )
+        self.language_combo = self.language_row.combo
+        language_card.add_row(self.language_row)
+        language_section.add_card(language_card)
+        page.add_section(language_section)
+
+        theme_section = SettingsSection(
+            _("Theme"),
+            _("Choose the visual theme."),
+            page,
+        )
         self.theme_group = QButtonGroup(page)
         self.theme_auto = RadioButton(_("Automatic"), page)
         self.theme_light = RadioButton(_("Light"), page)
         self.theme_dark = RadioButton(_("Dark"), page)
         for button in (self.theme_auto, self.theme_light, self.theme_dark):
             self.theme_group.addButton(button)
-            card.addWidget(button)
-        layout.addStretch(1)
+        theme_section.add_card(
+            SettingsRadioGroup(
+                self.theme_auto,
+                self.theme_light,
+                self.theme_dark,
+                parent=page,
+            )
+        )
+        page.add_section(theme_section)
+        page.add_stretch()
         return page
 
     def _notifications_page(self):
-        page, layout = self._page(
+        page = SettingsPage(
             _("Notifications and privacy"),
             _("Decide how much message information appears in native notification banners."),
+            self,
         )
-        card = self._card(page, layout)
-        self.notifications_enabled = CheckBox(_("Enable desktop notifications"), page)
-        self.notify_photo = CheckBox(_("Show contact photo"), page)
-        self.notify_name = CheckBox(_("Show contact or group name"), page)
-        self.notify_preview = CheckBox(_("Show message preview"), page)
-        for checkbox in (
-            self.notifications_enabled,
-            self.notify_photo,
-            self.notify_name,
-            self.notify_preview,
-        ):
-            card.addWidget(checkbox)
-        layout.addStretch(1)
+        desktop_section = SettingsSection(
+            _("Desktop notifications"),
+            _("Choose whether ZapZap may show desktop notifications."),
+            page,
+        )
+        desktop_card = SettingsCard(page)
+        self.notifications_enabled_row = SettingsSwitchRow(
+            _("Enable notifications"),
+            _("Allow ZapZap to publish native desktop notifications for WhatsApp activity."),
+        )
+        self.notifications_enabled = self.notifications_enabled_row.checkbox
+        desktop_card.add_row(self.notifications_enabled_row)
+        desktop_section.add_card(desktop_card)
+        page.add_section(desktop_section)
+
+        privacy_section = SettingsSection(
+            _("Notification privacy"),
+            _("Limit what is visible in notification banners."),
+            page,
+        )
+        privacy_card = SettingsCard(page)
+        self.notify_photo_row = SettingsSwitchRow(
+            _("Show contact photo"),
+            _("Display the sender avatar when it is available."),
+        )
+        self.notify_name_row = SettingsSwitchRow(
+            _("Show contact name"),
+            _("Display the sender or group name."),
+        )
+        self.notify_preview_row = SettingsSwitchRow(
+            _("Show message preview"),
+            _("Display the message text in the notification."),
+        )
+        self.notify_photo = self.notify_photo_row.checkbox
+        self.notify_name = self.notify_name_row.checkbox
+        self.notify_preview = self.notify_preview_row.checkbox
+        for row in (self.notify_photo_row, self.notify_name_row, self.notify_preview_row):
+            privacy_card.add_row(row)
+        privacy_section.add_card(privacy_card)
+        page.add_section(privacy_section)
+        page.add_stretch()
         return page
 
     def _background_page(self):
-        page, layout = self._page(
+        page = SettingsPage(
             _("Background behavior"),
             _("Choose whether ZapZap should stay available from the tray and start with your session."),
+            self,
         )
-        card = self._card(page, layout)
-        self.tray_enabled = CheckBox(_("Show icon in the system tray"), page)
-        self.tray_counter = CheckBox(_("Show unread counter on the tray icon"), page)
-        self.keep_background = CheckBox(_("Keep running in the background when closing the window"), page)
-        self.confirm_close = CheckBox(_("Ask for confirmation before closing"), page)
-        self.start_system = CheckBox(_("Start with the system"), page)
-        self.start_minimized = CheckBox(_("Start minimized"), page)
-        for checkbox in (
-            self.tray_enabled,
-            self.tray_counter,
-            self.keep_background,
-            self.confirm_close,
-            self.start_system,
-            self.start_minimized,
-        ):
-            card.addWidget(checkbox)
-        layout.addStretch(1)
+        tray_section = SettingsSection(
+            _("Tray icon"),
+            _("Control tray icon visibility and unread counter."),
+            page,
+        )
+        tray_card = SettingsCard(page)
+        self.tray_enabled_row = SettingsSwitchRow(
+            _("Enable tray icon"),
+            _("Show ZapZap in the system tray."),
+        )
+        self.tray_counter_row = SettingsSwitchRow(
+            _("Notification counter"),
+            _("Show unread notifications on the tray icon."),
+        )
+        self.tray_enabled = self.tray_enabled_row.checkbox
+        self.tray_counter = self.tray_counter_row.checkbox
+        tray_card.add_row(self.tray_enabled_row)
+        tray_card.add_row(self.tray_counter_row)
+        tray_section.add_card(tray_card)
+        page.add_section(tray_section)
+
+        window_section = SettingsSection(
+            _("Window behavior"),
+            _("Configure close behavior."),
+            page,
+        )
+        window_card = SettingsCard(page)
+        self.keep_background_row = SettingsSwitchRow(
+            _("Keep running in the background"),
+            _("Hide the main window instead of quitting when it is closed."),
+        )
+        self.confirm_close_row = SettingsSwitchRow(
+            _("Confirm before closing the window"),
+            _("Ask for confirmation before closing ZapZap."),
+        )
+        self.keep_background = self.keep_background_row.checkbox
+        self.confirm_close = self.confirm_close_row.checkbox
+        window_card.add_row(self.keep_background_row)
+        window_card.add_row(self.confirm_close_row)
+        window_section.add_card(window_card)
+        page.add_section(window_section)
+
+        startup_section = SettingsSection(
+            _("Startup"),
+            _("Control how ZapZap behaves when your desktop session starts."),
+            page,
+        )
+        startup_card = SettingsCard(page)
+        self.start_system_row = SettingsSwitchRow(
+            _("Start with the system"),
+            _("Create or remove the desktop autostart entry."),
+        )
+        self.start_minimized_row = SettingsSwitchRow(
+            _("Start minimized"),
+            _("Open ZapZap in the background instead of showing the main window."),
+        )
+        self.start_system = self.start_system_row.checkbox
+        self.start_minimized = self.start_minimized_row.checkbox
+        startup_card.add_row(self.start_system_row)
+        startup_card.add_row(self.start_minimized_row)
+        startup_section.add_card(startup_card)
+        page.add_section(startup_section)
+        page.add_stretch()
         return page
 
     def _files_page(self):
-        page, layout = self._page(
+        page = SettingsPage(
             _("Downloads and typing"),
             _("Choose where files are saved and enable spell checking when dictionaries are available."),
+            self,
         )
-        card = self._card(page, layout)
-        card.addWidget(QLabel(_("Download directory")))
-        path_row = QHBoxLayout()
-        self.download_path = LineEdit(parent=page)
+        downloads_section = SettingsSection(
+            _("Downloads"),
+            _("Choose where downloaded files are saved."),
+            page,
+        )
+        downloads_card = SettingsCard(page)
+        self.download_path_row = SettingsPathRow(
+            _("Download directory"),
+            _("Set a custom folder or keep the current download location."),
+            button_text=_("Choose folder"),
+        )
+        self.download_path = self.download_path_row.line_edit
         self.download_path.setReadOnly(True)
-        self.btn_download_path = Button(_("Choose folder"), parent=page)
-        path_row.addWidget(self.download_path, 1)
-        path_row.addWidget(self.btn_download_path)
-        card.addLayout(path_row)
-        self.spellcheck_enabled = CheckBox(_("Enable spell checker"), page)
-        card.addWidget(self.spellcheck_enabled)
-        card.addWidget(QLabel(_("Dictionary language")))
-        self.dictionary_combo = ComboBox(page)
-        card.addWidget(self.dictionary_combo)
-        self.dictionary_hint = QLabel(_("No compiled dictionaries were found. You can configure dictionaries later in Settings."), page)
-        self.dictionary_hint.setObjectName("InitialSetupHint")
-        self.dictionary_hint.setWordWrap(True)
-        card.addWidget(self.dictionary_hint)
-        layout.addStretch(1)
+        self.btn_download_path = self.download_path_row.button
+        downloads_card.add_row(self.download_path_row)
+        downloads_section.add_card(downloads_card)
+        page.add_section(downloads_section)
+
+        spell_section = SettingsSection(
+            _("Spell checker"),
+            _("Select compiled dictionaries and where ZapZap should look for them."),
+            page,
+        )
+        spell_card = SettingsCard(page)
+        self.spellcheck_enabled_row = SettingsSwitchRow(
+            _("Enable spell checker"),
+            _("Use Qt WebEngine spell checking with the selected dictionary."),
+        )
+        self.dictionary_row = SettingsSelectRow(
+            _("Dictionary language"),
+            _("Recognizes only compiled dictionaries (.bdic)."),
+        )
+        self.dictionary_hint = SettingsInfoBox(
+            _("No compiled dictionaries were found. You can configure dictionaries later in Settings."),
+            "warning",
+        )
+        self.spellcheck_enabled = self.spellcheck_enabled_row.checkbox
+        self.dictionary_combo = self.dictionary_row.combo
+        spell_card.add_row(self.spellcheck_enabled_row)
+        spell_card.add_row(self.dictionary_row)
+        spell_card.add_row(self.dictionary_hint)
+        spell_section.add_card(spell_card)
+        page.add_section(spell_section)
+        page.add_stretch()
         return page
 
     def _permissions_page(self):
-        page, layout = self._page(
+        page = SettingsPage(
             _("Essential permissions"),
             _("Allow only the WhatsApp Web permissions you want to grant automatically."),
+            self,
         )
-        card = self._card(page, layout)
-        self.permission_microphone = CheckBox(_("Microphone"), page)
-        self.permission_camera = CheckBox(_("Camera"), page)
-        self.permission_screen = CheckBox(_("Screen sharing"), page)
-        self.webrtc_shield = CheckBox(_("Reduce WebRTC IP exposure"), page)
-        for checkbox in (
-            self.permission_microphone,
-            self.permission_camera,
-            self.permission_screen,
-            self.webrtc_shield,
+        section = SettingsSection(
+            _("Permissions"),
+            _("When an option is unchecked, ZapZap will ask again in each session."),
+            page,
+        )
+        card = SettingsCard(page)
+        card.add_row(
+            SettingsInfoBox(
+                _("Enable only the permissions you want to grant automatically when the page requests them."),
+            )
+        )
+        self.permission_microphone_row = SettingsSwitchRow(
+            _("Microphone"),
+            _("Automatically allow access to your microphone."),
+        )
+        self.permission_camera_row = SettingsSwitchRow(
+            _("Camera"),
+            _("Automatically allow access to your camera."),
+        )
+        self.permission_screen_row = SettingsSwitchRow(
+            _("Screen contents"),
+            _("Automatically allow sharing of screen contents."),
+        )
+        self.webrtc_shield_row = SettingsSwitchRow(
+            _("WebRTC shield"),
+            _("Reduce WebRTC IP exposure."),
+        )
+        self.permission_microphone = self.permission_microphone_row.checkbox
+        self.permission_camera = self.permission_camera_row.checkbox
+        self.permission_screen = self.permission_screen_row.checkbox
+        self.webrtc_shield = self.webrtc_shield_row.checkbox
+        for row in (
+            self.permission_microphone_row,
+            self.permission_camera_row,
+            self.permission_screen_row,
+            self.webrtc_shield_row,
         ):
-            card.addWidget(checkbox)
-        hint = QLabel(_("When a permission is off, ZapZap will ask again when WhatsApp Web requests it."), page)
-        hint.setObjectName("InitialSetupHint")
-        hint.setWordWrap(True)
-        card.addWidget(hint)
-        layout.addStretch(1)
+            card.add_row(row)
+        section.add_card(card)
+        page.add_section(section)
+        page.add_stretch()
         return page
 
     def _finish_page(self):
-        page, layout = self._page(
+        page = SettingsPage(
             _("You're ready"),
-            _("ZapZap will save these preferences now. Advanced options like proxy, custom CSS/JavaScript, Flatpak permissions, and performance tweaks remain available in Settings."),
+            _("ZapZap will save these preferences now. Advanced options remain available in Settings."),
+            self,
         )
-        card = self._card(page, layout)
-        done = QLabel(_("You can revisit all choices from Settings at any time."), page)
-        done.setObjectName("InitialSetupCompletion")
-        done.setWordWrap(True)
-        card.addWidget(done)
-        layout.addStretch(1)
+        section = SettingsSection(
+            _("Finish setup"),
+            _("Review advanced options later whenever you need them."),
+            page,
+        )
+        card = SettingsCard(page)
+        card.add_row(
+            SettingsInfoBox(
+                _("You can revisit all choices from Settings at any time. Proxy, custom CSS/JavaScript, Flatpak permissions, and performance tweaks are still available there."),
+                "success",
+            )
+        )
+        section.add_card(card)
+        page.add_section(section)
+        page.add_stretch()
         return page
 
     def _apply_style(self):
         self.setStyleSheet("""
-            QDialog#InitialSetupDialog { background: palette(window); color: palette(text); }
-            QFrame#InitialSetupSidebar { background: palette(base); border-right: 1px solid palette(mid); min-width: 230px; max-width: 280px; }
-            QLabel#InitialSetupTitle { font-size: 22px; font-weight: 800; }
-            QLabel#InitialSetupSubtitle, QLabel#InitialSetupPageDescription, QLabel#InitialSetupHint { color: palette(placeholder-text); }
-            QLabel#InitialSetupPageTitle { font-size: 24px; font-weight: 800; }
-            QFrame#InitialSetupCard { background: palette(base); border: 1px solid palette(mid); border-radius: 16px; }
-            QFrame#InitialSetupFooter { background: palette(base); border-top: 1px solid palette(mid); }
-            QPushButton#InitialSetupStepButton { border: 0; border-radius: 10px; padding: 10px 12px; text-align: left; background: transparent; color: palette(text); }
-            QPushButton#InitialSetupStepButton:hover { background: palette(alternate-base); }
-            QPushButton#InitialSetupStepButton[active="true"] { background: palette(alternate-base); color: palette(highlight); font-weight: 700; }
-            QLabel#InitialSetupCompletion { font-size: 16px; font-weight: 600; }
+            QDialog#InitialSetupDialog {
+                background: palette(window);
+                color: palette(text);
+            }
+            QFrame#InitialSetupSidebar {
+                background: palette(base);
+                border-right: 1px solid palette(mid);
+                min-width: 230px;
+                max-width: 280px;
+            }
+            QLabel#InitialSetupTitle {
+                font-size: 22px;
+                font-weight: 800;
+            }
+            QLabel#InitialSetupSubtitle {
+                color: palette(placeholder-text);
+            }
+            QFrame#InitialSetupFooter {
+                background: palette(base);
+                border-top: 1px solid palette(mid);
+            }
+            QPushButton#InitialSetupStepButton {
+                border: 0;
+                border-radius: 10px;
+                padding: 10px 12px;
+                text-align: left;
+                background: transparent;
+                color: palette(text);
+            }
+            QPushButton#InitialSetupStepButton:hover {
+                background: palette(alternate-base);
+            }
+            QPushButton#InitialSetupStepButton[active="true"] {
+                background: palette(alternate-base);
+                color: palette(highlight);
+                font-weight: 700;
+            }
         """)
 
     def set_step(self, index: int):


### PR DESCRIPTION
### Motivation
- Introduce a guided first-run setup to let users pick language, theme, notifications, background behavior, download path, dictionaries and permissions.
- Persist onboarding choices into existing managers so defaults are applied consistently across the app.
- Prevent the app from hiding to background on first run so the onboarding dialog is shown to the user.

### Description
- Adds a new `features/initial_setup` feature with `controller.py`, `model.py`, and `view.py` to implement the onboarding dialog MVC, and an empty `__init__.py` to register the package.
- Implements `InitialSetupView` as a modal `QDialog` with multiple pages and controls for language, theme, notifications, tray/background, downloads, dictionaries and permissions, and styling via `setStyleSheet`.
- Implements `InitialSetupModel` to read/write settings through `SettingsManager` and coordinate with `TranslationManager`, `ThemeManager`, `DictionariesManager`, `DownloadManager`, `AutostartManager`, `SysTrayManager`, and `PermissionsManager`.
- Implements `InitialSetupController` to wire the view and model, drive navigation, load and save settings, and expose `should_show()` to indicate whether onboarding should be shown.
- Integrates onboarding into startup in `zapzap/app/application.py` by importing `InitialSetupController`, checking `InitialSetupController.should_show()`, preventing `--hideStart`/`system/start_background` from hiding the main window when onboarding is required, and showing the dialog with `QTimer.singleShot(0, ...)` after startup.

### Testing
- No automated tests were added for the new onboarding feature and no automated test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ee915030c832b8710fe9dd480f138)