### PR TITLE
Implement interface restart lifecycle

### DIFF
--- a/zapzap/app/application.py
+++ b/zapzap/app/application.py
@@ -21,6 +21,14 @@ from zapzap.core.i18n.translation_manager import TranslationManager
 from zapzap.features.initial_setup.controller import InitialSetupController
 
 
+def create_main_window():
+    """Build a fresh MainWindow instance using the current runtime settings."""
+    mainwindow_inside = MainWindowController()
+    csr_enabled = SettingsManager.get("system/csr", False)
+    return ClientSideRenderingController(
+        mainwindow_inside, enabled=True) if csr_enabled else mainwindow_inside
+
+
 def main():
     # Desativa todos os prints do código
     # sys.stdout = open(os.devnull, 'w')
@@ -46,19 +54,14 @@ def main():
     SetupManager.apply_qt_scale_factor_rounding_policy()
 
     # Callback instance
-    app.messageReceived.connect(lambda result: main_window.xdgOpenChat(result))
+    app.messageReceived.connect(
+        lambda result: app.getWindow().xdgOpenChat(result))
 
     # Initialize ThemeManager
     ThemeManager.start()
 
     # Create main window
-    mainwindow_inside = MainWindowController()
-    csr_enabled = SettingsManager.get("system/csr", False)
-    main_window = ClientSideRenderingController(
-        mainwindow_inside, enabled=True) if csr_enabled else mainwindow_inside
-    app.setWindow(main_window)
-    app.setActivationWindow(main_window)
-    main_window.load_settings()
+    main_window = app.startInterface(create_main_window)
 
     ProxyManager.apply()
 
@@ -78,15 +81,16 @@ def main():
         main_window.show()
 
     if should_show_initial_setup:
-        QTimer.singleShot(0, lambda: InitialSetupController(main_window).exec())
+        QTimer.singleShot(
+            0, lambda: InitialSetupController(app.getWindow()).exec())
 
     app.aboutToQuit.connect(ThemeManager.stop)
-    app.aboutToQuit.connect(main_window.browser.shutdown)
+    app.aboutToQuit.connect(app.shutdownInterface)
 
     exit_code = app.exec()
 
     # Defensive fallback for abnormal shutdown paths where aboutToQuit may not have run.
     ThemeManager.stop()
-    main_window.browser.shutdown()
+    app.shutdownInterface()
 
     return exit_code

--- a/zapzap/app/single_application.py
+++ b/zapzap/app/single_application.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from PyQt6.QtCore import Qt, QTextStream, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import Qt, QTextStream, QTimer, pyqtSignal, pyqtSlot
 from PyQt6.QtNetwork import QLocalServer, QLocalSocket
 from PyQt6.QtWidgets import QApplication
 
@@ -23,6 +23,8 @@ class SingleApplication(QApplication):
         self._inStream = None
         self._server = None
         self.window = None
+        self._window_factory = None
+        self._interface_restarting = False
 
         if self._isRunning:
             self._outStream = QTextStream(self._outSocket)
@@ -103,3 +105,57 @@ class SingleApplication(QApplication):
 
     def getWindow(self):
         return self.window
+
+    def startInterface(self, window_factory):
+        """Create and register the main interface window."""
+        self._window_factory = window_factory
+        return self._create_interface_window()
+
+    def restartInterface(self, show=True):
+        """Rebuild the MainWindow without restarting the QApplication process.
+
+        This is useful for settings that only need a new MainWindow/browser tree.
+        Settings consumed before QApplication/QtWebEngine initialization still need
+        a full application restart.
+        """
+        if not self._window_factory or self._interface_restarting:
+            return False
+
+        self._interface_restarting = True
+        QTimer.singleShot(0, lambda: self._restart_interface_now(show))
+        return True
+
+    def shutdownInterface(self):
+        """Release resources owned by the current interface window."""
+        if not self.window:
+            return
+
+        browser = getattr(self.window, "browser", None)
+        if browser:
+            browser.shutdown()
+
+    def _restart_interface_now(self, show=True):
+        old_window = self.window
+        was_visible = old_window.isVisible() if old_window else False
+
+        if old_window:
+            if hasattr(old_window, "_save_window_state"):
+                old_window._save_window_state()
+            self.shutdownInterface()
+            old_window.hide()
+            old_window.deleteLater()
+
+        new_window = self._create_interface_window()
+        if show and was_visible:
+            new_window.show()
+
+        self._interface_restarting = False
+
+    def _create_interface_window(self):
+        window = self._window_factory()
+        self.setWindow(window)
+        self.setActivationWindow(window)
+        window.load_settings()
+        from zapzap.features.tray.sys_tray_manager import SysTrayManager
+        SysTrayManager.bind_window(window)
+        return window

--- a/zapzap/features/settings/pages/appearance/controller.py
+++ b/zapzap/features/settings/pages/appearance/controller.py
@@ -92,6 +92,7 @@ class AppearanceSettingsController(AppearanceSettingsView):
         self.csr_direction_comboBox.currentTextChanged.connect(
             self._handle_csr_direction
         )
+        self.btn_restart_interface.clicked.connect(self._restart_interface)
 
     @staticmethod
     def _set_selected_radio(selected_value, radio_map):
@@ -179,3 +180,6 @@ class AppearanceSettingsController(AppearanceSettingsView):
     def _handle_csr_direction(self, direction_label):
         self.model.csr_buttons_direction = direction_label
         self._refresh_csr_buttons()
+
+    def _restart_interface(self):
+        QApplication.instance().restartInterface()

--- a/zapzap/features/settings/pages/appearance/view.py
+++ b/zapzap/features/settings/pages/appearance/view.py
@@ -3,6 +3,7 @@
 from gettext import gettext as _
 
 from zapzap.ui.components import RadioButton
+from zapzap.features.settings.components import SettingsActionRow
 from zapzap.features.settings.components import SettingsRadioGroup
 from zapzap.features.settings.components import SettingsCard
 from zapzap.features.settings.components import SettingsPage
@@ -146,10 +147,17 @@ class AppearanceSettingsView(SettingsPage):
             ["right", "left"],
         )
         self.csr_direction_comboBox = self.csr_direction_row.combo
+        self.restart_interface_row = SettingsActionRow(
+            _("Restart interface"),
+            _("Rebuild the main window to apply window decoration mode changes."),
+            _("Restart interface"),
+        )
+        self.btn_restart_interface = self.restart_interface_row.button
         card.add_row(self.csr_groupBox)
         card.add_row(self.csr_theme_row)
         card.add_row(self.csr_show_minimize_row)
         card.add_row(self.csr_show_maximize_row)
         card.add_row(self.csr_direction_row)
+        card.add_row(self.restart_interface_row)
         section.add_card(card)
         self.add_section(section)

--- a/zapzap/features/settings/pages/performance_experimental/controller.py
+++ b/zapzap/features/settings/pages/performance_experimental/controller.py
@@ -2,6 +2,8 @@
 
 from gettext import gettext as _
 
+from PyQt6.QtWidgets import QApplication
+
 from zapzap.features.settings.pages.performance_experimental.model import PerformanceExperimentalSettingsModel
 from zapzap.features.settings.pages.performance_experimental.view import PerformanceExperimentalSettingsView
 
@@ -51,6 +53,7 @@ class PerformanceExperimentalSettingsController(PerformanceExperimentalSettingsV
         self.js_memory_limit.currentIndexChanged.connect(
             lambda index: setattr(self.model, "js_memory_limit_index", index)
         )
+        self.btn_restart_interface.clicked.connect(self._restart_interface)
         self.btn_restore.clicked.connect(self._restore_settings)
 
     def _handle_cache_type(self, value):
@@ -62,6 +65,9 @@ class PerformanceExperimentalSettingsController(PerformanceExperimentalSettingsV
     def _restore_settings(self):
         self.model.restore_defaults()
         self._load_settings()
+
+    def _restart_interface(self):
+        QApplication.instance().restartInterface()
 
     def _add_tooltips(self):
         self.cache_type.setToolTip(

--- a/zapzap/features/settings/pages/performance_experimental/view.py
+++ b/zapzap/features/settings/pages/performance_experimental/view.py
@@ -47,6 +47,15 @@ class PerformanceExperimentalSettingsView(SettingsPage):
                 "warning",
             )
         )
+        self.restart_interface_row = SettingsActionRow(
+            _("Restart interface"),
+            _(
+                "Rebuild the browser interface now. Chromium startup flags still require restarting ZapZap."
+            ),
+            _("Restart interface"),
+        )
+        self.btn_restart_interface = self.restart_interface_row.button
+        card.add_row(self.restart_interface_row)
         section.add_card(card)
         self.add_section(section)
 

--- a/zapzap/features/tray/sys_tray_manager.py
+++ b/zapzap/features/tray/sys_tray_manager.py
@@ -69,6 +69,10 @@ class SysTrayManager:
 
     def _setup_connections(self):
         """Configura as conexões dos sinais das ações da bandeja."""
+        self._actions["donation"].triggered.connect(
+            lambda: QDesktopServices.openUrl(QUrl(__donationPage__))
+        )
+
         main_window = QApplication.instance().getWindow()
 
         if main_window is None:
@@ -78,14 +82,31 @@ class SysTrayManager:
                     break
 
         if main_window:
-            self._tray.activated.connect(main_window.show_window)
-            self._actions["show"].triggered.connect(main_window.show_window)
-            self._actions["settings"].triggered.connect(
-                lambda: self._open_settings(main_window))
-            self._actions["donation"].triggered.connect(
-                lambda: QDesktopServices.openUrl(QUrl(__donationPage__))
-            )
-            self._actions["exit"].triggered.connect(main_window.closeEvent)
+            self.bind_window(main_window)
+
+    @classmethod
+    def bind_window(cls, main_window):
+        """Reconnect tray actions to the current MainWindow instance."""
+        instance = cls.instance()
+        instance._disconnect_window_actions()
+        instance._bound_window = main_window
+        instance._tray.activated.connect(main_window.show_window)
+        instance._actions["show"].triggered.connect(main_window.show_window)
+        instance._actions["settings"].triggered.connect(
+            lambda: instance._open_settings(main_window))
+        instance._actions["exit"].triggered.connect(main_window.closeEvent)
+
+    def _disconnect_window_actions(self):
+        for signal in (
+            self._tray.activated,
+            self._actions["show"].triggered,
+            self._actions["settings"].triggered,
+            self._actions["exit"].triggered,
+        ):
+            try:
+                signal.disconnect()
+            except TypeError:
+                pass
 
     def _set_icon(self, icon_type: TrayIcon.Type, number_notifications=0):
         """Atualiza o ícone da bandeja."""


### PR DESCRIPTION
### Motivation
- Provide a way to rebuild the UI (MainWindow + browser tree) at runtime so settings that require rebuilding the interface can be applied without restarting the whole process.
- Ensure system tray actions and other callbacks continue to point to the current MainWindow after a rebuild.

### Description
- Add a `create_main_window()` factory and route startup through `SingleApplication.startInterface()` so the app keeps a reusable window factory. (`zapzap/app/application.py`)
- Implement `SingleApplication.startInterface()`, `SingleApplication.restartInterface()`, `SingleApplication.shutdownInterface()` and internal helpers to create, tear down and replace the interface window without quitting the `QApplication`. (`zapzap/app/single_application.py`)
- Update message/callback wiring to always resolve the window via `app.getWindow()` and switch about-to-quit cleanup to call `app.shutdownInterface()` so resources are released consistently. (`zapzap/app/application.py`)
- Update `SysTrayManager` to support `bind_window()` and to disconnect/rebind tray actions to the active `MainWindow` so tray menu and activation keep working after interface rebuilds. (`zapzap/features/tray/sys_tray_manager.py`)
- Note in code that flags/args applied before Qt/QtWebEngine initialization (Chromium flags, etc.) still require a full process restart and are not covered by the interface restart.

### Testing
- Ran byte-compilation: `python -m compileall zapzap/app zapzap/features/tray` — succeeded.
- Ran unit tests: `pytest -q` — all tests passed (`7 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a56964dcafc832b969482ad2928a7c9)