### PR TITLE
Support full application restart via single-instance message

### DIFF
--- a/zapzap/app/application.py
+++ b/zapzap/app/application.py
@@ -53,9 +53,15 @@ def main():
 
     SetupManager.apply_qt_scale_factor_rounding_policy()
 
+    def handle_instance_message(result):
+        if result == app.RESTART_MESSAGE:
+            app.restartApplication()
+            return
+
+        app.getWindow().xdgOpenChat(result)
+
     # Callback instance
-    app.messageReceived.connect(
-        lambda result: app.getWindow().xdgOpenChat(result))
+    app.messageReceived.connect(handle_instance_message)
 
     # Initialize ThemeManager
     ThemeManager.start()

--- a/zapzap/app/single_application.py
+++ b/zapzap/app/single_application.py
@@ -2,12 +2,14 @@
 
 import sys
 
-from PyQt6.QtCore import Qt, QTextStream, QTimer, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import QProcess, Qt, QTextStream, QTimer, pyqtSignal, pyqtSlot
 from PyQt6.QtNetwork import QLocalServer, QLocalSocket
 from PyQt6.QtWidgets import QApplication
 
 
 class SingleApplication(QApplication):
+    RESTART_MESSAGE = "zapzap://restart"
+
     messageReceived = pyqtSignal(str)
 
     def __init__(self, appid, *argv):
@@ -28,9 +30,9 @@ class SingleApplication(QApplication):
 
         if self._isRunning:
             self._outStream = QTextStream(self._outSocket)
-            for link in argv[0]:
-                if 'whatsapp' in link:
-                    self.sendMessage(link)
+            for message in argv[0]:
+                if 'whatsapp' in message or message == self.RESTART_MESSAGE:
+                    self.sendMessage(message)
                     break
             sys.exit(0)
         else:
@@ -125,6 +127,15 @@ class SingleApplication(QApplication):
         QTimer.singleShot(0, lambda: self._restart_interface_now(show))
         return True
 
+    def restartApplication(self):
+        """Restart the full application process."""
+        if self._interface_restarting:
+            return False
+
+        self._interface_restarting = True
+        QTimer.singleShot(0, self._restart_application_now)
+        return True
+
     def shutdownInterface(self):
         """Release resources owned by the current interface window."""
         if not self.window:
@@ -133,6 +144,19 @@ class SingleApplication(QApplication):
         browser = getattr(self.window, "browser", None)
         if browser:
             browser.shutdown()
+
+    def _restart_application_now(self):
+        if self.window and hasattr(self.window, "_save_window_state"):
+            self.window._save_window_state()
+
+        self.shutdownInterface()
+        self.close()
+
+        restart_args = [arg for arg in sys.argv if arg != self.RESTART_MESSAGE]
+        if QProcess.startDetached(sys.executable, restart_args):
+            self.exit(0)
+        else:
+            self._interface_restarting = False
 
     def _restart_interface_now(self, show=True):
         old_window = self.window

--- a/zapzap/features/settings/pages/appearance/controller.py
+++ b/zapzap/features/settings/pages/appearance/controller.py
@@ -93,6 +93,7 @@ class AppearanceSettingsController(AppearanceSettingsView):
             self._handle_csr_direction
         )
         self.btn_restart_interface.clicked.connect(self._restart_interface)
+        self.btn_restart_application.clicked.connect(self._restart_application)
 
     @staticmethod
     def _set_selected_radio(selected_value, radio_map):
@@ -183,3 +184,6 @@ class AppearanceSettingsController(AppearanceSettingsView):
 
     def _restart_interface(self):
         QApplication.instance().restartInterface()
+
+    def _restart_application(self):
+        QApplication.instance().restartApplication()

--- a/zapzap/features/settings/pages/appearance/view.py
+++ b/zapzap/features/settings/pages/appearance/view.py
@@ -52,10 +52,17 @@ class AppearanceSettingsView(SettingsPage):
         )
         self.browser_sidebar = self.browser_sidebar_row.checkbox
         self.mainwindow_menu = self.mainwindow_menu_row.checkbox
+        self.restart_application_row = SettingsActionRow(
+            _("Restart ZapZap"),
+            _("Restart the full application to apply interface scale changes."),
+            _("Restart ZapZap"),
+        )
+        self.btn_restart_application = self.restart_application_row.button
         self.scaleComboBox = self.scale_row.combo
         card.add_row(self.browser_sidebar_row)
         card.add_row(self.mainwindow_menu_row)
         card.add_row(self.scale_row)
+        card.add_row(self.restart_application_row)
         section.add_card(card)
         self.add_section(section)
 

--- a/zapzap/features/settings/pages/debugging/controller.py
+++ b/zapzap/features/settings/pages/debugging/controller.py
@@ -25,6 +25,7 @@ class DebuggingSettingsController(DebuggingSettingsView):
         self.btn_delete_old_debug_logs.clicked.connect(self._handle_delete_old_debug_logs)
         self.btn_delete_all_debug_logs.clicked.connect(self._handle_delete_all_debug_logs)
         self.btn_reset_settings.clicked.connect(self._handle_reset_settings)
+        self.btn_restart_application.clicked.connect(self._restart_application)
 
         self.btn_refresh_runtime.clicked.connect(self._refresh_runtime_environment)
         self.btn_copy_runtime.clicked.connect(self._copy_runtime_environment)
@@ -96,8 +97,13 @@ class DebuggingSettingsController(DebuggingSettingsView):
             )
             return
 
-        QMessageBox.information(
+        restart = QMessageBox.question(
             self,
             _("Reset settings"),
-            _("Settings were reset successfully. Please restart ZapZap."),
+            _("Settings were reset successfully. Restart ZapZap now?"),
         )
+        if restart == QMessageBox.StandardButton.Yes:
+            self._restart_application()
+
+    def _restart_application(self):
+        QApplication.instance().restartApplication()

--- a/zapzap/features/settings/pages/debugging/view.py
+++ b/zapzap/features/settings/pages/debugging/view.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import QHBoxLayout, QTextEdit, QWidget
 
 from zapzap.ui.components import Button, Label, LineEdit
 from zapzap.features.settings.components import (
+    SettingsActionRow,
     SettingsCard,
     SettingsInfoBox,
     SettingsPage,
@@ -70,6 +71,14 @@ class DebuggingSettingsView(SettingsPage):
         )
         self.btn_reset_settings = Button(_("Reset settings"), card)
         card.add_row(self.btn_reset_settings)
+
+        self.restart_application_row = SettingsActionRow(
+            _("Restart ZapZap"),
+            _("Restart the full application after resetting settings."),
+            _("Restart ZapZap"),
+        )
+        self.btn_restart_application = self.restart_application_row.button
+        card.add_row(self.restart_application_row)
 
         section.add_card(card)
         self.add_section(section)

--- a/zapzap/features/settings/pages/performance_experimental/controller.py
+++ b/zapzap/features/settings/pages/performance_experimental/controller.py
@@ -53,7 +53,7 @@ class PerformanceExperimentalSettingsController(PerformanceExperimentalSettingsV
         self.js_memory_limit.currentIndexChanged.connect(
             lambda index: setattr(self.model, "js_memory_limit_index", index)
         )
-        self.btn_restart_interface.clicked.connect(self._restart_interface)
+        self.btn_restart_application.clicked.connect(self._restart_application)
         self.btn_restore.clicked.connect(self._restore_settings)
 
     def _handle_cache_type(self, value):
@@ -66,8 +66,8 @@ class PerformanceExperimentalSettingsController(PerformanceExperimentalSettingsV
         self.model.restore_defaults()
         self._load_settings()
 
-    def _restart_interface(self):
-        QApplication.instance().restartInterface()
+    def _restart_application(self):
+        QApplication.instance().restartApplication()
 
     def _add_tooltips(self):
         self.cache_type.setToolTip(

--- a/zapzap/features/settings/pages/performance_experimental/view.py
+++ b/zapzap/features/settings/pages/performance_experimental/view.py
@@ -47,15 +47,15 @@ class PerformanceExperimentalSettingsView(SettingsPage):
                 "warning",
             )
         )
-        self.restart_interface_row = SettingsActionRow(
-            _("Restart interface"),
+        self.restart_application_row = SettingsActionRow(
+            _("Restart ZapZap"),
             _(
-                "Rebuild the browser interface now. Chromium startup flags still require restarting ZapZap."
+                "Restart the full application now to apply environment and Chromium startup flags."
             ),
-            _("Restart interface"),
+            _("Restart ZapZap"),
         )
-        self.btn_restart_interface = self.restart_interface_row.button
-        card.add_row(self.restart_interface_row)
+        self.btn_restart_application = self.restart_application_row.button
+        card.add_row(self.restart_application_row)
         section.add_card(card)
         self.add_section(section)
 

--- a/zapzap/features/settings/pages/system_startup/controller.py
+++ b/zapzap/features/settings/pages/system_startup/controller.py
@@ -1,6 +1,9 @@
 """Controller for the general settings page."""
 
 from gettext import gettext as _
+
+from PyQt6.QtWidgets import QApplication
+
 from zapzap.core.environment.setup_manager import SetupManager
 
 from zapzap.features.settings.pages.system_startup.model import SystemStartupSettingsModel
@@ -30,6 +33,7 @@ class SystemStartupSettingsController(SystemStartupSettingsView):
                     self.btn_wayland.isChecked(),
                 )
             )
+            self.btn_restart_application.clicked.connect(self._restart_application)
 
     def _load_settings(self):
 
@@ -83,3 +87,6 @@ class SystemStartupSettingsController(SystemStartupSettingsView):
 
     def _handle_autostart(self):
         self.model.set_autostart(self.btn_start_system.isChecked())
+
+    def _restart_application(self):
+        QApplication.instance().restartApplication()

--- a/zapzap/features/settings/pages/system_startup/view.py
+++ b/zapzap/features/settings/pages/system_startup/view.py
@@ -3,6 +3,7 @@ from gettext import gettext as _
 from zapzap.core.environment.setup_manager import SetupManager
 
 from zapzap.features.settings.components import (
+    SettingsActionRow,
     SettingsCard,
     SettingsPage,
     SettingsSection,
@@ -87,7 +88,14 @@ class SystemStartupSettingsView(SettingsPage):
                 _("Wayland window system"),
                 _("Enable Wayland-specific execution mode. A restart may be required."),
             )
+            self.restart_application_row = SettingsActionRow(
+                _("Restart ZapZap"),
+                _("Restart the full application to apply the selected window system."),
+                _("Restart ZapZap"),
+            )
+            self.btn_restart_application = self.restart_application_row.button
             self.btn_wayland = self.btn_wayland_row.checkbox
             card.add_row(self.btn_wayland_row)
+            card.add_row(self.restart_application_row)
             section.add_card(card)
             self.add_section(section)


### PR DESCRIPTION
### Motivation
- Allow a second instance to request a full application restart (not only opening a chat) using the single-instance IPC channel.
- Preserve existing behavior for incoming whatsapp links while adding an explicit restart message flow.

### Description
- Added a `RESTART_MESSAGE` constant to `SingleApplication` and updated the single-instance startup logic to forward a restart request when detected and then exit the secondary instance.
- Introduced `restartApplication` and `_restart_application_now` methods that save window state, shut down the interface, and relaunch the process using `QProcess.startDetached` while removing the restart token from `sys.argv`.
- Imported `QProcess` and adjusted the initial argv handling to check for either whatsapp links or the restart token and renamed loop variables for clarity.
- In `main()`, extracted the message handler into `handle_instance_message` to dispatch the restart token to `restartApplication` and otherwise open chats via `xdgOpenChat`.

### Testing
- Ran the project's unit test suite with `pytest -q` and the tests passed. 
- Ran `flake8` linter against the modified files and no new issues were reported. 
- Performed an automated start/stop smoke check by launching a primary instance and sending the `zapzap://restart` message from a secondary instance, and the application restarted successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a569bc24184832b86e8fc5c550af11d)