### PR TITLE
fix(gpu): auto-detect headless secondary GPU and set --disable-gpu-compositing to prevent startup SIGABRT

### DIFF
--- a/zapzap/services/GpuEnvironment.py
+++ b/zapzap/services/GpuEnvironment.py
@@ -1,0 +1,78 @@
+"""Detecção de topologia multi-GPU para evitar crash de GBM/EGL no Chromium.
+
+Em máquinas com mais de uma GPU onde a GPU secundária é "headless" (sem monitor
+conectado) enquanto outra GPU controla a tela, o processo de GPU do Chromium
+pode selecionar o render node da GPU errada para alocar buffers GBM. O import
+entre dispositivos distintos falha (gbm_bo_import -> EGL_BAD_MATCH) e o processo
+de GPU aborta, derrubando o aplicativo na inicialização.
+
+Detectar essa topologia permite aplicar apenas a flag mínima
+``--disable-gpu-compositing`` quando (e somente quando) ela é necessária,
+preservando a aceleração completa para a maioria (máquinas com uma única GPU).
+
+Usa apenas leituras de sysfs (ABI estável do Linux); funciona em X11 e Wayland,
+sem dependências novas e sem privilégios de root.
+"""
+from __future__ import annotations
+
+import glob
+import os
+
+
+def _pci_slot(drm_name: str) -> str | None:
+    """Slot PCI (ex.: '0000:03:00.0') de um nó DRM ('card1' ou 'renderD128')."""
+    try:
+        return os.path.basename(
+            os.path.realpath(os.path.join("/sys/class/drm", drm_name, "device"))
+        )
+    except OSError:
+        return None
+
+
+def _slots_driving_a_connected_display() -> set[str]:
+    """Slots PCI cujas GPUs possuem ao menos uma saída (connector) conectada."""
+    slots: set[str] = set()
+    for status_path in glob.glob("/sys/class/drm/card*-*/status"):
+        try:
+            with open(status_path, "r") as fh:
+                if fh.read().strip() != "connected":
+                    continue
+        except OSError:
+            continue
+        # Ex.: '/sys/class/drm/card1-HDMI-A-2/status' -> 'card1'
+        connector = os.path.basename(os.path.dirname(status_path))  # 'card1-HDMI-A-2'
+        card = connector.split("-", 1)[0]
+        slot = _pci_slot(card)
+        if slot:
+            slots.add(slot)
+    return slots
+
+
+def has_headless_secondary_gpu() -> bool:
+    """Retorna ``True`` quando existe um render node cuja GPU não controla
+    nenhuma tela conectada enquanto outra GPU controla a tela — exatamente a
+    topologia que dispara o crash cross-GPU ``gbm_bo_import`` / ``EGL_BAD_MATCH``
+    no processo de GPU do Chromium.
+
+    Falha em segurança (retorna ``False``) em qualquer erro de leitura de sysfs,
+    em máquinas com uma única GPU e quando não há informação de conector, de modo
+    que máquinas single-GPU (a maioria dos usuários) nunca são afetadas.
+    """
+    render_nodes = glob.glob("/dev/dri/renderD*")
+    if len(render_nodes) <= 1:
+        return False  # GPU única: mantém aceleração completa
+
+    render_slots = {
+        slot
+        for node in render_nodes
+        if (slot := _pci_slot(os.path.basename(node)))
+    }
+    if len(render_slots) <= 1:
+        return False  # nós redundantes da mesma GPU
+
+    display_slots = _slots_driving_a_connected_display()
+    if not display_slots:
+        return False  # sem informação de conector -> não interferir
+
+    # Alguma GPU com render node não controla nenhuma tela conectada?
+    return any(slot not in display_slots for slot in render_slots)

--- a/zapzap/services/SetupManager.py
+++ b/zapzap/services/SetupManager.py
@@ -82,6 +82,17 @@ class SetupManager:
             environ["QT_OPENGL"] = "software"
             add_flag("--disable-gpu")
 
+        # Workaround automático: multi-GPU com GPU secundária "headless"
+        # (ex.: dGPU sem monitor + iGPU controlando a tela). O processo de GPU do
+        # Chromium pode alocar buffers GBM no render node errado -> gbm_bo_import
+        # nulo -> EGL_BAD_MATCH -> SIGABRT na inicialização. --disable-gpu-compositing
+        # é a flag mínima que evita o crash preservando aceleração de raster/vídeo.
+        # Desative com: zapzap --setSettings performance/auto_gpu_workaround false
+        if SettingsManager.get("performance/auto_gpu_workaround", True):
+            from zapzap.services.GpuEnvironment import has_headless_secondary_gpu
+            if has_headless_secondary_gpu():
+                add_flag("--disable-gpu-compositing")
+
         # --------------------------------------------------
         # Processos
         # --------------------------------------------------


### PR DESCRIPTION
Fixes #790.

## Problem
On a machine with two GPUs where the **discrete GPU is headless** (no display attached) and an **integrated GPU drives the only monitor**, the default `zapzap` launcher aborts on startup with a GPU-process `SIGABRT`:

```
qtwebengine .../ui/gfx/linux/gbm_wrapper.cc:451] nullptr returned from gbm_bo_import
Failed to create GBM buffer for EGL. Fallback to EGL-based buffer allocation.
EGL: Failed to create EGLImage: EGL_BAD_MATCH
Failed to create GBM buffer. NativePixmap allocation failed.
-> SIGABRT (GPU process aborts, kills the app)
```

The Performance settings would fix it, but the app crashes **before** the user can open Settings — a chicken-and-egg gap. Only the AppImage build has a default `--disable-gpu` guard; deb/rpm/snap/pip/Flatpak users have no escape hatch.

## Root cause
Chromium's Ozone/DRM path picks the headless dGPU's render node for GBM buffer allocation while ANGLE's EGL/display context is on the iGPU that drives the compositor. The cross-device import is (correctly) rejected with `EGL_BAD_MATCH` and the GPU process aborts. This is the Chromium multi-GPU render-node-selection class (https://issues.chromium.org/issues/343352540); the M140 fix disambiguates nodes by *driver name*, which can't help when **both** nodes are `amdgpu`.

Confirmed locally: `DRI_PRIME` does not help (Ozone ignores it); `--disable-gpu-compositing` prevents the crash and keeps raster/video accel.

## Fix
- New `zapzap/services/GpuEnvironment.py`: stdlib-only sysfs probe `has_headless_secondary_gpu()` — true when >1 DRM render node exists and at least one GPU drives no *connected* display.
- In `SetupManager.apply()` (the pre-Qt env chokepoint), gated behind a new `performance/auto_gpu_workaround` setting (**default on**), add only `--disable-gpu-compositing` when that topology is detected.

**Fail-safe:** returns `False` on single-GPU machines, on redundant nodes of one GPU, and on any unreadable sysfs / missing connector info — single-GPU users are never touched. No new deps, no root, works on X11 and Wayland. Respects a user-supplied `QTWEBENGINE_CHROMIUM_FLAGS` (merged, not overwritten, as of #499).

Opt out: `zapzap --setSettings performance/auto_gpu_workaround false`

## Testing
RX 9060 XT (headless) + Ryzen 7 9700X iGPU, KDE Plasma Wayland, mesa 26.1.4, qt6-webengine 6.11.1:
- Detector returns `True` on this topology; `False` for single-GPU, both-GPUs-driving-display, and no-connector-info (unit-tested with mocks).
- `SetupManager.apply()` injects the flag; the opt-out setting suppresses it.
- **Before:** default launcher SIGABRT'd instantly. **After:** launches cleanly, WhatsApp Web loads, no `gbm_bo_import` / `EGL_BAD_MATCH`.

## Notes
Targets `main`; happy to rebase onto `7.0` if you prefer — satisfies the "Não há crash na inicialização" item in #782. A follow-up could add a Performance checkbox for `auto_gpu_workaround` plus a crash-sentinel fallback (e.g. #657).
