### PR TITLE
Honor DRI_PRIME in Qt WebEngine

### DIFF
--- a/tests/test_gpu_environment.py
+++ b/tests/test_gpu_environment.py
@@ -19,6 +19,7 @@ _gpu_environment = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_gpu_environment)
 
 has_headless_secondary_gpu = _gpu_environment.has_headless_secondary_gpu
+preferred_render_node = _gpu_environment.preferred_render_node
 
 
 class GpuEnvironmentTests(unittest.TestCase):
@@ -36,6 +37,96 @@ class GpuEnvironmentTests(unittest.TestCase):
             self._add_gpu(drm, "card1", "renderD129", connected=False)
 
             self.assertTrue(has_headless_secondary_gpu(drm))
+
+    def test_single_gpu_dri_prime_does_not_add_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            drm = Path(tmp)
+            self._add_gpu(
+                drm, "card0", "renderD128", connected=True,
+                vendor="0x1002", device_id="0x73e3",
+            )
+
+            self.assertIsNone(
+                preferred_render_node(
+                    drm, "/test/dev/dri", dri_prime="1002:73e3"
+                )
+            )
+
+    def test_numeric_dri_prime_is_not_guessed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            drm = Path(tmp)
+            self._add_gpu(drm, "card0", "renderD128", connected=True)
+            self._add_gpu(drm, "card1", "renderD129", connected=True)
+
+            self.assertIsNone(
+                preferred_render_node(drm, "/test/dev/dri", dri_prime="1")
+            )
+
+    def test_empty_dri_prime_does_not_add_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            drm = Path(tmp)
+            self._add_gpu(drm, "card0", "renderD128", connected=True)
+            self._add_gpu(drm, "card1", "renderD129", connected=False)
+
+            self.assertIsNone(
+                preferred_render_node(drm, "/test/dev/dri", dri_prime="")
+            )
+
+    def test_dri_prime_vendor_device_overrides_ambiguous_connectors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            drm = Path(tmp)
+            self._add_gpu(
+                drm, "card0", "renderD128", connected=True,
+                vendor="0x1002", device_id="0x73e3",
+            )
+            self._add_gpu(
+                drm, "card1", "renderD129", connected=True,
+                vendor="0x10de", device_id="0x2b85",
+            )
+
+            self.assertEqual(
+                preferred_render_node(
+                    drm, "/test/dev/dri", dri_prime="1002:73e3!"
+                ),
+                Path("/test/dev/dri/renderD128"),
+            )
+
+    def test_dri_prime_pci_selector_maps_to_render_node(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            drm = Path(tmp)
+            self._add_gpu(
+                drm, "card0", "renderD128", connected=True,
+                pci_slot="0000:05:00.0",
+            )
+            self._add_gpu(
+                drm, "card1", "renderD129", connected=True,
+                pci_slot="0000:01:00.0",
+            )
+
+            self.assertEqual(
+                preferred_render_node(
+                    drm, "/test/dev/dri", dri_prime="pci-0000_05_00_0"
+                ),
+                Path("/test/dev/dri/renderD128"),
+            )
+
+    def test_duplicate_vendor_device_selector_is_ambiguous(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            drm = Path(tmp)
+            self._add_gpu(
+                drm, "card0", "renderD128", connected=True,
+                vendor="0x1002", device_id="0x73e3",
+            )
+            self._add_gpu(
+                drm, "card1", "renderD129", connected=True,
+                vendor="0x1002", device_id="0x73e3",
+            )
+
+            self.assertIsNone(
+                preferred_render_node(
+                    drm, "/test/dev/dri", dri_prime="1002:73e3"
+                )
+            )
 
     def test_both_gpus_with_displays_return_false(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -66,8 +157,16 @@ class GpuEnvironmentTests(unittest.TestCase):
 
             self.assertFalse(has_headless_secondary_gpu(drm))
 
-    def _add_gpu(self, drm, card, render, connected, connector=True):
-        device = drm / "devices" / card
+    def _add_gpu(
+        self, drm, card, render, connected, connector=True,
+        vendor=None, device_id=None, pci_slot=None,
+    ):
+        device = drm / "devices" / (pci_slot or card)
+        device.mkdir(parents=True, exist_ok=True)
+        if vendor is not None:
+            device.joinpath("vendor").write_text(vendor + "\n", encoding="utf-8")
+        if device_id is not None:
+            device.joinpath("device").write_text(device_id + "\n", encoding="utf-8")
         self._add_node(drm, card, device)
         self._add_node(drm, render, device)
         if connector:

--- a/zapzap/core/environment/gpu_environment.py
+++ b/zapzap/core/environment/gpu_environment.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from os import getenv
 from pathlib import Path
-from typing import Dict, List, Set, Union
+from typing import Dict, List, Optional, Set, Union
 
 
 _SYS_CLASS_DRM = Path("/sys/class/drm")
+_DEV_DRI = Path("/dev/dri")
 
 
 def has_headless_secondary_gpu(drm_path: Union[str, Path] = _SYS_CLASS_DRM) -> bool:
@@ -45,13 +47,91 @@ def has_headless_secondary_gpu(drm_path: Union[str, Path] = _SYS_CLASS_DRM) -> b
         return False
 
 
+def preferred_render_node(
+    drm_path: Union[str, Path] = _SYS_CLASS_DRM,
+    dev_dri_path: Union[str, Path] = _DEV_DRI,
+    dri_prime: Optional[str] = None,
+) -> Optional[Path]:
+    """Return the render node requested by an unambiguous DRI_PRIME.
+
+    Qt WebEngine does not always propagate Mesa's device selection to its
+    Chromium GPU process. Mirror unambiguous PCI and vendor/device DRI_PRIME
+    selectors as a Chromium render-node override on multi-GPU systems.
+    """
+
+    selector = getenv("DRI_PRIME", "") if dri_prime is None else dri_prime
+    if not selector.strip():
+        return None
+
+    try:
+        drm_dir = Path(drm_path)
+        render_nodes = _render_nodes_by_device(drm_dir)
+        if len(render_nodes) < 2:
+            return None
+        selected = _render_node_for_dri_prime(render_nodes, selector)
+        if selected is not None:
+            return Path(dev_dri_path) / selected.name
+    except OSError:
+        return None
+
+    return None
+
+
 def _render_devices(drm_dir: Path) -> Set[Path]:
-    devices: Set[Path] = set()
-    for render_node in drm_dir.glob("renderD*"):
+    return set(_render_nodes_by_device(drm_dir))
+
+
+def _render_nodes_by_device(drm_dir: Path) -> Dict[Path, Path]:
+    nodes: Dict[Path, Path] = {}
+    for render_node in sorted(drm_dir.glob("renderD*")):
         if not render_node.name[7:].isdigit():
             continue
-        devices.add(_device_path(render_node))
-    return devices
+        nodes[_device_path(render_node)] = render_node
+    return nodes
+
+
+def _render_node_for_dri_prime(
+    render_nodes: Dict[Path, Path], selector: str
+) -> Optional[Path]:
+    selector = selector.strip().lower()
+    if selector.endswith("!"):
+        selector = selector[:-1]
+    if not selector:
+        return None
+
+    if selector.startswith("pci-"):
+        parts = selector[4:].split("_")
+        if len(parts) != 4:
+            return None
+        try:
+            slot = f"{int(parts[0], 16):04x}:{int(parts[1], 16):02x}:"
+            slot += f"{int(parts[2], 16):02x}.{int(parts[3], 16):x}"
+        except ValueError:
+            return None
+        for device, render_node in render_nodes.items():
+            if device.name.lower() == slot:
+                return render_node
+        return None
+
+    ids = selector.split(":")
+    if len(ids) != 2:
+        return None
+    try:
+        requested_vendor = int(ids[0], 16)
+        requested_device = int(ids[1], 16)
+    except ValueError:
+        return None
+
+    matches: List[Path] = []
+    for device, render_node in render_nodes.items():
+        try:
+            vendor = int(device.joinpath("vendor").read_text(encoding="utf-8"), 0)
+            device_id = int(device.joinpath("device").read_text(encoding="utf-8"), 0)
+        except (OSError, ValueError):
+            continue
+        if vendor == requested_vendor and device_id == requested_device:
+            matches.append(render_node)
+    return matches[0] if len(matches) == 1 else None
 
 
 def _connector_states_by_device(drm_dir: Path) -> Dict[Path, List[str]]:

--- a/zapzap/core/environment/setup_manager.py
+++ b/zapzap/core/environment/setup_manager.py
@@ -3,7 +3,10 @@ from PyQt6.QtCore import QFileInfo
 from zapzap.core.platform import IS_WINDOWS
 from zapzap.features.dictionaries.dictionaries_manager import DictionariesManager
 from zapzap.core.config.settings_manager import SettingsManager
-from zapzap.core.environment.gpu_environment import has_headless_secondary_gpu
+from zapzap.core.environment.gpu_environment import (
+    has_headless_secondary_gpu,
+    preferred_render_node,
+)
 
 
 class SetupManager:
@@ -73,11 +76,15 @@ class SetupManager:
         if SettingsManager.get("performance/disable_gpu", False):
             add_flag("--disable-gpu")
 
-        if (
-            SettingsManager.get("performance/auto_gpu_workaround", True)
-            and has_headless_secondary_gpu()
-        ):
-            add_flag("--disable-gpu-compositing")
+        if SettingsManager.get("performance/auto_gpu_workaround", True):
+            has_render_node_override = any(
+                flag.startswith("--render-node-override") for flag in flags
+            )
+            selected_render_node = preferred_render_node()
+            if selected_render_node and not has_render_node_override:
+                add_flag(f"--render-node-override={selected_render_node}")
+            elif has_headless_secondary_gpu():
+                add_flag("--disable-gpu-compositing")
 
         if SettingsManager.get("performance/in_process_gpu", False):
             add_flag("--in-process-gpu")

--- a/zapzap/features/settings/pages/performance_experimental/controller.py
+++ b/zapzap/features/settings/pages/performance_experimental/controller.py
@@ -98,8 +98,9 @@ class PerformanceExperimentalSettingsController(PerformanceExperimentalSettingsV
         )
         self.auto_gpu_workaround.setToolTip(
             _(
-                "Automatically adds --disable-gpu-compositing when ZapZap detects "
-                "multiple Linux render GPUs and one of them has no connected display.\n\n"
+                "Automatically honors an unambiguous DRI_PRIME selector on systems "
+                "with multiple Linux render GPUs. Otherwise, adds "
+                "--disable-gpu-compositing when one GPU has no connected display.\n\n"
                 "Disable this only if the automatic workaround causes problems. "
                 "Restart required."
             )

--- a/zapzap/features/settings/pages/performance_experimental/view.py
+++ b/zapzap/features/settings/pages/performance_experimental/view.py
@@ -101,9 +101,9 @@ class PerformanceExperimentalSettingsView(SettingsPage):
             _("Recommended only for old GPUs or problematic drivers."),
         )
         self.auto_gpu_workaround_row = SettingsSwitchRow(
-            _("Automatic headless GPU workaround"),
+            _("Automatic multi-GPU workaround"),
             _(
-                "Disables GPU compositing at startup when a secondary GPU has no connected display."
+                "Honors DRI_PRIME or adjusts GPU compositing for a headless secondary GPU."
             ),
         )
         self.disable_gpu_vsync_row = SettingsSwitchRow(


### PR DESCRIPTION
## What changed

- Resolve explicit Mesa `DRI_PRIME` PCI and vendor/device selectors to their DRM render node.
- Pass that node to Qt WebEngine through Chromium's `--render-node-override` when ZapZap's automatic GPU workaround is enabled.
- Preserve an existing user-supplied render-node override.
- Add coverage for PCI selectors, vendor/device selectors, single-GPU systems, numeric selectors, and ambiguous duplicate devices.

## Why

On multi-GPU Linux systems, Qt WebEngine's Chromium GPU process can select a different GPU from the one explicitly chosen through `DRI_PRIME`. Besides defeating the user's device preference, that can retain a removable or passthrough GPU and prevent a clean detach.

## Compatibility and scope

The new override is applied only when all of these conditions hold:

- ZapZap is running on a system exposing more than one DRM render device.
- The existing automatic GPU workaround is enabled.
- `DRI_PRIME` is explicitly set to a supported PCI or vendor/device selector.
- That selector resolves to exactly one render node.
- The user has not already supplied `--render-node-override`.

Without an explicit, uniquely resolved selector, ZapZap keeps its previous conservative headless-GPU fallback (`--disable-gpu-compositing`). Single-GPU systems, unset or invalid selectors, ambiguous identical GPUs, and existing overrides therefore retain their prior behavior. Numeric `DRI_PRIME` selectors are intentionally left untouched because mapping their Mesa enumeration to sysfs render nodes would require guessing.

## Validation

- `python -m unittest discover -s tests -v` (21/21 tests passed)
- `python -m compileall -q zapzap tests`
- `python -m build --wheel --no-isolation`
- `git diff --check`

The wheel build completed successfully; it emitted only the repository's existing setuptools license metadata deprecation warnings.
