### PR TITLE
fix: enhance dict path for non FHS linux distributions

### DIFF
--- a/zapzap/core/config/path_manager.py
+++ b/zapzap/core/config/path_manager.py
@@ -30,7 +30,7 @@ class PathManager:
         },
         Packaging.UNOFFICIAL: {
             "path": "",
-            "default": "/usr/share/qt6/qtwebengine_dictionaries",
+            "default": os.getenv("QTWEBENGINE_DICTIONARIES_PATH", os.path.join(os.path.expanduser("~"), ".local/share/zapzap/qtwebengine_dictionaries")),
         },
         Packaging.WINDOWS: {
             "path": "",


### PR DESCRIPTION
Hardcoding a Fedora/RHEL‑specific path for "unofficial" installs breaks on non‑FHS systems such as NixOS (see the issue reported in the Nixpkgs PR: https://github.com/NixOS/nixpkgs/pull/543474#issuecomment-5016495060).
This change first respects QTWEBENGINE_DICTIONARIES_PATH (like FLATPAK and SNAP) when set, and otherwise falls back to a per‑user directory under $HOME, which works across non‑FHS distributions.