### PR TITLE
Fix Flatpak autostart commandline type

### DIFF
--- a/tests/test_autostart_manager.py
+++ b/tests/test_autostart_manager.py
@@ -1,0 +1,23 @@
+"""Tests for Flatpak autostart requests."""
+
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from zapzap.features.startup.autostart_manager import AutostartManager
+
+
+class FlatpakAutostartTests(unittest.TestCase):
+    def test_commandline_is_marshaled_as_string_array(self):
+        dbus = MagicMock()
+        dbus.Array.side_effect = lambda values, signature=None: (values, signature)
+
+        with patch.dict(sys.modules, {"dbus": dbus}):
+            AutostartManager._handle_flatpak(True)
+
+        options = dbus.Interface.return_value.RequestBackground.call_args.args[1]
+        self.assertEqual((["zapzap", "--hideStart"], "s"), options["commandline"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/zapzap/features/startup/autostart_manager.py
+++ b/zapzap/features/startup/autostart_manager.py
@@ -53,7 +53,7 @@ class AutostartManager:
                 'reason': 'Zapzap autostart',
                 'autostart': enable_autostart,
                 'background': enable_autostart,
-                'commandline': dbus.Array(['zapzap', '--hideStart'])
+                'commandline': dbus.Array(['zapzap', '--hideStart'], signature='s')
             })
         except Exception as e:
             print(f"Error managing Flatpak autostart: {e}")


### PR DESCRIPTION
Closes #799

Flatpak's Background portal requires `commandline` to be marshalled as an array of strings. This adds the missing D-Bus element signature and a focused regression test for the request options.

Tested with `PYTHONPATH=. .venv/bin/pytest -q tests` (22 passed) and Ruff on the changed files.
