### PR TITLE
Preserve the maximized window state when restoring from the tray

### DIFF
--- a/tests/test_window_state_restore.py
+++ b/tests/test_window_state_restore.py
@@ -1,0 +1,96 @@
+"""Regression tests for restoring the maximized state of hidden windows."""
+
+import unittest
+
+from PyQt6.QtWidgets import QWidget
+
+from qt_test_case import QtTestCase
+from zapzap.ui.main_window.window_state import WindowStateMemory
+
+
+class _Window(WindowStateMemory, QWidget):
+    """Stand-in wired like the application windows."""
+
+    def __init__(self):
+        super().__init__()
+        self.is_fullscreen = False
+
+    def hideEvent(self, event):
+        self.remember_window_state()
+        super().hideEvent(event)
+
+    def restore_window(self):
+        self.show_in_remembered_state(self.is_fullscreen)
+
+
+class _DelegatingWrapper(WindowStateMemory, QWidget):
+    """Wrapper that forwards unknown attributes, like the CSR window."""
+
+    def __init__(self, inner):
+        super().__init__()
+        self.inner_window = inner
+
+    def __getattr__(self, name):
+        return getattr(self.inner_window, name)
+
+
+class WindowStateRestoreTest(QtTestCase):
+    def setUp(self):
+        self.window = _Window()
+        self.addCleanup(self.window.deleteLater)
+
+    def test_maximized_window_is_restored_maximized(self):
+        self.window.showMaximized()
+        self.assertTrue(self.window.isMaximized())
+
+        self.window.hide()
+        self.window.restore_window()
+
+        self.assertTrue(self.window.isMaximized())
+
+    def test_normal_window_is_restored_normal(self):
+        self.window.showNormal()
+
+        self.window.hide()
+        self.window.restore_window()
+
+        self.assertFalse(self.window.isMaximized())
+
+    def test_fullscreen_takes_precedence_over_maximized(self):
+        self.window.showMaximized()
+        self.window.hide()
+        self.window.is_fullscreen = True
+
+        self.window.restore_window()
+
+        self.assertTrue(self.window.isFullScreen())
+
+    def test_window_never_hidden_is_shown_normal(self):
+        self.window.show_in_remembered_state()
+
+        self.assertFalse(self.window.isMaximized())
+
+    def test_restoring_twice_keeps_the_state(self):
+        self.window.showMaximized()
+
+        for _ in range(2):
+            self.window.hide()
+            self.window.restore_window()
+
+        self.assertTrue(self.window.isMaximized())
+
+    def test_state_is_not_read_from_a_delegated_inner_window(self):
+        inner = _Window()
+        self.addCleanup(inner.deleteLater)
+        inner.showMaximized()
+        inner.hide()
+        wrapper = _DelegatingWrapper(inner)
+        self.addCleanup(wrapper.deleteLater)
+
+        wrapper.show_in_remembered_state()
+
+        self.assertFalse(wrapper.isMaximized())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zapzap/features/tray/sys_tray_manager.py
+++ b/zapzap/features/tray/sys_tray_manager.py
@@ -118,7 +118,7 @@ class SysTrayManager:
 
     def _open_settings(self, main_window):
         main_window.open_settings()
-        main_window.showNormal()
+        main_window.restore_window()
         main_window.activateWindow()
         main_window.raise_()
 

--- a/zapzap/ui/main_window/client_side_rendering_controller.py
+++ b/zapzap/ui/main_window/client_side_rendering_controller.py
@@ -10,9 +10,10 @@ from zapzap.core.config.settings_manager import SettingsManager
 from zapzap.features.alerts.alert_manager import AlertManager
 from zapzap.features.donation.controller import DonationController
 from zapzap.ui.main_window.client_side_rendering_view import ClientSideRenderingView
+from zapzap.ui.main_window.window_state import WindowStateMemory
 
 
-class ClientSideRenderingController(ClientSideRenderingView):
+class ClientSideRenderingController(WindowStateMemory, ClientSideRenderingView):
     """Coordinates lifecycle behavior for the CSR window wrapper."""
 
     def __init__(self, inner_window: QWidget, enabled: bool = True):
@@ -71,12 +72,13 @@ class ClientSideRenderingController(ClientSideRenderingView):
         self.hide()
         event.ignore()
 
+    def restore_window(self):
+        """Show the window in the state it held when it was hidden."""
+        self.show_in_remembered_state(self.inner_window.is_fullscreen)
+
     def show_window(self):
         if self.isHidden():
-            if self.inner_window.is_fullscreen:
-                self.showFullScreen()
-            else:
-                self.showNormal()
+            self.restore_window()
             QApplication.instance().setActiveWindow(self)
         elif not self.isActiveWindow():
             self.activateWindow()
@@ -85,6 +87,7 @@ class ClientSideRenderingController(ClientSideRenderingView):
             self.hide()
 
     def hideEvent(self, event):
+        self.remember_window_state()
         super().hideEvent(event)
 
     def __getattr__(self, name):

--- a/zapzap/ui/main_window/main_window_controller.py
+++ b/zapzap/ui/main_window/main_window_controller.py
@@ -19,9 +19,10 @@ from zapzap.features.settings.shell.settings_controller import SettingsControlle
 from zapzap.features.shortcuts.controller import ShortcutsController
 from zapzap.features.tray.sys_tray_manager import SysTrayManager
 from zapzap.ui.main_window.main_window_view import MainWindowView
+from zapzap.ui.main_window.window_state import WindowStateMemory
 
 
-class MainWindowController(MainWindowView):
+class MainWindowController(WindowStateMemory, MainWindowView):
     """
     Classe principal da interface do aplicativo.
     Controla a janela principal, incluindo o menu e interações com widgets centrais.
@@ -293,17 +294,27 @@ class MainWindowController(MainWindowView):
         self.hide()
         event.ignore()
 
+    def hideEvent(self, event):
+        """Guardar o estado da janela antes de ela ser ocultada."""
+        self.remember_window_state()
+        super().hideEvent(event)
+
     # === Controle de Visibilidade da Janela ===
+    def restore_window(self):
+        """Exibe a janela no estado em que ela estava ao ser ocultada."""
+        if self.parentWidget() is not None and hasattr(self.window(), "is_csr_wrapper"):
+            self.window().restore_window()
+            return
+
+        self.show_in_remembered_state(self.is_fullscreen)
+
     def show_window(self):
         if self.parentWidget() is not None and hasattr(self.window(), "is_csr_wrapper"):
             self.window().show_window()
             return
         """Alterna a visibilidade da janela principal."""
         if self.isHidden():
-            if self.is_fullscreen:
-                self.showFullScreen()
-            else:
-                self.showNormal()
+            self.restore_window()
             QApplication.instance().setActiveWindow(self)
         elif not self.isActiveWindow():
             self.activateWindow()

--- a/zapzap/ui/main_window/window_state.py
+++ b/zapzap/ui/main_window/window_state.py
@@ -1,0 +1,28 @@
+"""Window state that survives a trip to the system tray."""
+
+
+class WindowStateMemory:
+    """Remembers whether a window was maximized while it stays hidden.
+
+    ``QWidget.showNormal()`` shows a window "neither maximized nor minimized
+    nor fullscreen", so restoring a window that was hidden to the tray while
+    maximized brings it back in its normal size. Windows record their state as
+    they are hidden and reapply it when they are shown again.
+    """
+
+    # Defined on the class so the attribute always resolves, even on wrappers
+    # that forward unknown attributes to an inner window via ``__getattr__``.
+    _restore_maximized = False
+
+    def remember_window_state(self) -> None:
+        """Capture the state to return to. Call before hiding the window."""
+        self._restore_maximized = self.isMaximized()
+
+    def show_in_remembered_state(self, fullscreen: bool = False) -> None:
+        """Show the window in the state captured when it was hidden."""
+        if fullscreen:
+            self.showFullScreen()
+        elif self._restore_maximized:
+            self.showMaximized()
+        else:
+            self.showNormal()


### PR DESCRIPTION
Fixes #723.

## What happens

`show_window()` brings a hidden window back with `showNormal()`. Qt documents that as showing a window "neither maximized nor minimized nor fullscreen", so a window that was maximized when it went to the tray returns at its normal size.

The state is not lost by the compositor. Qt keeps the maximized flag across `hide()` and `show()`, and `showNormal()` is what clears it. Checked against an offscreen widget:

| call | `isMaximized()` afterwards |
| --- | --- |
| `showMaximized()` | True |
| inside `hideEvent` | True |
| after `hide()` | True |
| `show()` | True |
| `showNormal()` | False |

Three places call `showNormal()` when restoring:

* `MainWindowController.show_window()`
* `ClientSideRenderingController.show_window()`
* `SysTrayManager._open_settings()`

That matches the observation in the issue that restoring from the launcher and restoring from the tray behave differently.

## The change

`WindowStateMemory` records whether a window is maximized as it is hidden, and reapplies that state when it is shown again. Both window controllers mix it in, and the tray's Settings action now calls `restore_window()` instead of `showNormal()`.

`_restore_maximized` is a class attribute rather than something set in `__init__`. `ClientSideRenderingController` forwards unknown attributes to its inner window through `__getattr__`, so an instance attribute would be missing on the wrapper until it had been hidden once, and the lookup would fall through to the inner window's value. A class attribute always resolves on the wrapper itself. There is a test covering this.

Fullscreen still takes precedence over maximized, so `is_fullscreen` behaviour is unchanged.

## Testing

Reproduced against a real `MainWindowController` under `QT_QPA_PLATFORM=offscreen`.

Before:

```
after hide, isMaximized: True
after show_window(), isMaximized: False
```

After:

```
after hide, isMaximized: True
after show_window(), isMaximized: True
```

`tests/test_window_state_restore.py` covers the maximized case, the normal case, fullscreen precedence, repeated hide and show cycles, a window that has never been hidden, and the delegation case described above. I checked that they fail against the old logic and pass with the new one.

The suite goes from 14 to 15 passing. `test_desktop_application_dbus.py` and `test_notification_window_activation.py` fail on my machine both before and after this branch. They import `zapzap.*` without importing `qt_test_case` first, so the repository root never reaches `sys.path`. That is fixed separately in #815.

One caveat: I could not test on KDE Plasma Wayland, where the issue was reproduced. My verification was on the offscreen platform. The fix tracks the state in Python rather than relying on the platform layer to preserve it, so it should not depend on the compositor, but confirmation on Plasma would be worth having.

