### PR TITLE
Fix two test modules that cannot be run directly

### DIFF
--- a/tests/test_desktop_application_dbus.py
+++ b/tests/test_desktop_application_dbus.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 from PyQt6.QtCore import QObject
 from PyQt6.QtDBus import QDBusConnection
 
+import qt_test_case  # noqa: F401  puts the repository root on sys.path
 from zapzap import __desktopid__
 from zapzap.app.desktop_application_dbus import (
     DesktopApplicationDBus,

--- a/tests/test_notification_window_activation.py
+++ b/tests/test_notification_window_activation.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, call, patch
 from PyQt6.QtCore import Qt
 from PyQt6.QtDBus import QDBusVariant
 
+import qt_test_case  # noqa: F401  puts the repository root on sys.path
 from zapzap.features.notifications.freedesktop_notification_backend import (
     DBusConnection,
     DBusNotification,


### PR DESCRIPTION
`tests/test_desktop_application_dbus.py` and `tests/test_notification_window_activation.py` fail to load when run directly:

```
$ python tests/test_notification_window_activation.py
ModuleNotFoundError: No module named 'zapzap'
```

Running a file directly puts that file's directory on `sys.path`, so `tests/` ends up there and the repository root does not. Both modules import `zapzap.*` at the top without importing `qt_test_case` first, which is where the other test modules pick up the root path.

Importing `qt_test_case` fixes both. It is the shared setup described in its own docstring as being for "directly executable unittest modules", and it inserts the repository root into `sys.path` along with setting `QT_QPA_PLATFORM` and isolating the XDG directories.

With this change the suite goes from 14 passing and 2 failing to 16 passing on my machine.

Worth noting that `dbus-python` is not required for either of these. The `import dbus` in `freedesktop_notification_backend.py` is already wrapped in `try`/`except`, and I confirmed both files pass with `dbus-python` uninstalled once the path is fixed.
