### PR TITLE
Add a setting to mute the notification sound

### DIFF
--- a/tests/test_notification_sound_setting.py
+++ b/tests/test_notification_sound_setting.py
@@ -1,0 +1,74 @@
+"""Tests for muting the desktop alert sound for new messages."""
+
+import unittest
+from unittest.mock import patch
+
+import qt_test_case  # noqa: F401  puts the repository root on sys.path
+from zapzap.features.notifications.freedesktop_notification_backend import (
+    DBusNotification,
+)
+from zapzap.features.notifications.portal_notification_backend import (
+    PortalNotificationBackend,
+)
+
+
+def _with_sound(enabled, module):
+    """Patch SettingsManager.get so notification/sound reads as `enabled`."""
+    return patch(
+        f"zapzap.features.notifications.{module}.SettingsManager.get",
+        side_effect=lambda key, default=None: (
+            enabled if key == "notification/sound" else default
+        ),
+    )
+
+
+class SuppressSoundHintTests(unittest.TestCase):
+    """The freedesktop backend carries the preference as a hint."""
+
+    @staticmethod
+    def _notification():
+        return DBusNotification("Title", "Body", "", 3000)
+
+    def test_muting_sets_the_suppress_sound_hint(self):
+        notification = self._notification()
+
+        notification.set_suppress_sound(True)
+
+        self.assertIs(notification.hints["suppress-sound"], True)
+
+    def test_allowing_sound_leaves_the_hint_false(self):
+        notification = self._notification()
+
+        notification.set_suppress_sound(False)
+
+        self.assertIs(notification.hints["suppress-sound"], False)
+
+    def test_hint_is_absent_until_it_is_set(self):
+        self.assertNotIn("suppress-sound", self._notification().hints)
+
+
+class PortalSoundFieldTests(unittest.TestCase):
+    """The portal backend carries the preference as a payload field."""
+
+    def test_muting_marks_the_notification_silent(self):
+        with _with_sound(False, "portal_notification_backend"):
+            fields = PortalNotificationBackend._extra_fields()
+
+        self.assertEqual(fields["sound"], "silent")
+
+    def test_allowing_sound_omits_the_field(self):
+        with _with_sound(True, "portal_notification_backend"):
+            fields = PortalNotificationBackend._extra_fields()
+
+        self.assertNotIn("sound", fields)
+
+    def test_the_other_extra_fields_are_kept_when_muting(self):
+        with _with_sound(False, "portal_notification_backend"):
+            fields = PortalNotificationBackend._extra_fields()
+
+        self.assertEqual(fields["category"], "im.received")
+        self.assertEqual(fields["display-hint"], ["show-as-new"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notifications_settings_ui.py
+++ b/tests/test_notifications_settings_ui.py
@@ -17,11 +17,19 @@ from zapzap.features.settings.pages.notifications.view import (
 
 class FakeNotificationsSettingsModel:
 
-    def __init__(self, enabled=True, photo=True, name=True, message=True):
+    def __init__(
+        self,
+        enabled=True,
+        photo=True,
+        name=True,
+        message=True,
+        sound=True,
+    ):
         self.enabled = enabled
         self.show_photo = photo
         self.show_name = name
         self.show_message_preview = message
+        self.sound = sound
         self.donation_message_enabled = False
 
 
@@ -51,6 +59,7 @@ class NotificationsSettingsUiTests(QtTestCase):
         self.assertEqual(page.show_photo.title_label.text(), "Contact photo")
         self.assertEqual(page.show_name.title_label.text(), "Contact name")
         self.assertEqual(page.show_msg.title_label.text(), "Message preview")
+        self.assertEqual(page.sound.title_label.text(), "Notification sound")
         self.assertEqual(
             page.donationMessage.title_label.text(),
             "Support reminders",
@@ -104,6 +113,22 @@ class NotificationsSettingsUiTests(QtTestCase):
             [model.show_photo, model.show_name, model.show_message_preview],
             [True, False, True],
         )
+
+    def test_notification_sound_switch_persists_the_preference(self):
+        page, model = self._controller(sound=True)
+
+        page.sound.checkbox.setChecked(False)
+        self.assertFalse(model.sound)
+
+        page.sound.checkbox.setChecked(True)
+        self.assertTrue(model.sound)
+
+    def test_privacy_presets_leave_the_notification_sound_alone(self):
+        page, model = self._controller(sound=True)
+
+        page.maximum_privacy_action.trigger()
+
+        self.assertTrue(model.sound)
 
     def test_privacy_presets_update_existing_switch_settings(self):
         page, model = self._controller()

--- a/zapzap/core/config/settings/notifications.py
+++ b/zapzap/core/config/settings/notifications.py
@@ -12,6 +12,7 @@ class NotificationSettings(BaseSettings):
     _SHOW_PHOTO = ("notification/show_photo", True)
     _SHOW_NAME = ("notification/show_name", True)
     _SHOW_MESSAGE_PREVIEW = ("notification/show_msg", True)
+    _SOUND = ("notification/sound", True)
     # This legacy key stores whether reminders are hidden, despite its name.
     _DONATION_MESSAGE_HIDDEN = ("notification/donation_message", False)
 
@@ -46,6 +47,14 @@ class NotificationSettings(BaseSettings):
     @show_message_preview.setter
     def show_message_preview(self, value: bool) -> None:
         self._set_bool(self._SHOW_MESSAGE_PREVIEW, value)
+
+    @property
+    def sound(self) -> bool:
+        return self._get_bool(self._SOUND)
+
+    @sound.setter
+    def sound(self, value: bool) -> None:
+        self._set_bool(self._SOUND, value)
 
     @property
     def donation_message_enabled(self) -> bool:

--- a/zapzap/features/notifications/freedesktop_notification_backend.py
+++ b/zapzap/features/notifications/freedesktop_notification_backend.py
@@ -254,6 +254,10 @@ class DBusNotification:
     def set_category(self, category: str):
         self.hints["category"] = category
 
+    def set_suppress_sound(self, suppress: bool):
+        """Ask the server not to play its alert sound for this notification."""
+        self.hints["suppress-sound"] = bool(suppress)
+
     def setIconPath(self, icon_path: str):
         """
         Necessário para ícones dinâmicos (avatar).
@@ -335,6 +339,9 @@ class FreedesktopNotificationBackend:
 
         notify.set_urgency(Urgency.NORMAL)
         notify.set_category("im.received")
+        notify.set_suppress_sound(
+            not SettingsManager.get("notification/sound", True)
+        )
         notify.setIconPath(icon_path)  # 👈 ESSENCIAL
 
         def on_click(activation_token=None):

--- a/zapzap/features/notifications/portal_notification_backend.py
+++ b/zapzap/features/notifications/portal_notification_backend.py
@@ -62,6 +62,17 @@ class PortalNotificationBackend(QObject):
     # Notify with Dynamic Fallback
     # ---------------------------------------------------------
 
+    @staticmethod
+    def _extra_fields() -> dict:
+        """Payload fields that only newer portal versions understand."""
+        fields = {
+            "display-hint": ["show-as-new"],
+            "category": "im.received",
+        }
+        if not SettingsManager.get("notification/sound", True):
+            fields["sound"] = "silent"
+        return fields
+
     def notify(
         self,
         page: WebView,
@@ -88,10 +99,7 @@ class PortalNotificationBackend(QObject):
 
         extra_fields = {}
         if self._supports_extra_fields:
-            extra_fields = {
-                "display-hint": ["show-as-new"],
-                "category": "im.received",
-            }
+            extra_fields = self._extra_fields()
 
         attempts = []
 

--- a/zapzap/features/settings/pages/notifications/controller.py
+++ b/zapzap/features/settings/pages/notifications/controller.py
@@ -21,6 +21,7 @@ class NotificationsSettingsController(NotificationsSettingsView):
         self.show_photo.checkbox.setChecked(self.model.show_photo)
         self.show_name.checkbox.setChecked(self.model.show_name)
         self.show_msg.checkbox.setChecked(self.model.show_message_preview)
+        self.sound.checkbox.setChecked(self.model.sound)
         self.donationMessage.checkbox.setChecked(
             self.model.donation_message_enabled
         )
@@ -43,6 +44,9 @@ class NotificationsSettingsController(NotificationsSettingsView):
         )
         self.show_msg.checkbox.toggled.connect(
             self._handle_toggle_show_message_preview
+        )
+        self.sound.checkbox.toggled.connect(
+            self._handle_toggle_sound
         )
         self.donationMessage.checkbox.toggled.connect(
             self._handle_toggle_donation_message
@@ -80,6 +84,9 @@ class NotificationsSettingsController(NotificationsSettingsView):
 
     def _handle_toggle_show_message_preview(self, is_enabled: bool):
         self.model.show_message_preview = is_enabled
+
+    def _handle_toggle_sound(self, is_enabled: bool):
+        self.model.sound = is_enabled
 
     def _handle_toggle_donation_message(self, is_enabled: bool):
         self.model.donation_message_enabled = is_enabled

--- a/zapzap/features/settings/pages/notifications/model.py
+++ b/zapzap/features/settings/pages/notifications/model.py
@@ -19,6 +19,15 @@ class NotificationsSettingsModel:
         self._settings.enabled = value
 
     @property
+    def sound(self) -> bool:
+        """Whether the notification server may play its alert sound."""
+        return self._settings.sound
+
+    @sound.setter
+    def sound(self, value: bool) -> None:
+        self._settings.sound = value
+
+    @property
     def show_photo(self) -> bool:
         """Whether contact photos are shown in notifications."""
         return self._settings.show_photo

--- a/zapzap/features/settings/pages/notifications/view.py
+++ b/zapzap/features/settings/pages/notifications/view.py
@@ -55,10 +55,15 @@ class NotificationsSettingsView(SettingsPage):
             _("Message preview"),
             _("Show the content of the received message."),
         )
+        self.sound = SettingsSwitchRow(
+            _("Notification sound"),
+            _("Let the desktop play its alert sound for new messages."),
+        )
         self.notification_content_rows = (
             self.show_photo,
             self.show_name,
             self.show_msg,
+            self.sound,
         )
         for row in self.notification_content_rows:
             self._configure_accessibility(row)


### PR DESCRIPTION
Addresses #642, where the alert sound for new messages is described as too loud with no way to change it.

## Why

There is no sound handling anywhere under `zapzap/features/notifications/`. The desktop notification server picks the sound, so the only way to silence ZapZap today is to silence notifications for the whole system.

## What this adds

A "Notification sound" switch under desktop notifications, next to the existing content switches. It defaults to on, so nothing changes until someone turns it off, and it greys out with the rest of the group when notifications are disabled.

When it is off:

* the freedesktop backend sets the `suppress-sound` hint, which has been in the desktop notification spec since 1.2
* the portal backend adds `"sound": "silent"` to the notification payload

The portal field goes into the extra fields group rather than the base payload. That group already has fallback attempts behind it, so a portal that does not understand `sound` degrades the same way it already does for `display-hint` and `category`, instead of breaking notifications outright. Building those fields moved into a small `_extra_fields()` helper so the behaviour can be tested directly.

## Scope

This covers muting only. The issue also mentions wanting a different sound, which would mean the `sound-file` or `sound-name` hints plus a file picker. That felt like a separate change, so I left it out rather than bundle two things together. Happy to follow up with it if you want it.

## Testing

`tests/test_notification_sound_setting.py` covers both backends: the hint is absent until set, set to true when muting and false otherwise, and the portal payload gains `sound: silent` only when muted while keeping its other fields.

`tests/test_notifications_settings_ui.py` gains coverage that the switch shows the right label, that toggling it persists through the controller, and that the privacy presets leave it alone.

Suite result on my machine: 15 passing. The 2 failures in `test_desktop_application_dbus.py` and `test_notification_window_activation.py` are unrelated to this branch and are fixed separately in #815.

I could not verify the sound audibly against every notification server, so the tests assert the hint and payload rather than the audio itself.
