### PR TITLE
Remove the stored data of accounts that were disabled at startup

### DIFF
--- a/tests/test_account_data_removal.py
+++ b/tests/test_account_data_removal.py
@@ -1,0 +1,88 @@
+"""Regression tests for deleting an account's data from disk."""
+
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import qt_test_case  # noqa: F401  puts the repository root on sys.path
+from zapzap.features.browser.web.web_view import WebView
+
+
+class _Account:
+    """Stands in for a WebView, exposing only what remove_files touches.
+
+    Instantiating a real WebView pulls in QtWebEngine, which needs a
+    QApplication built with a program name. remove_files is called unbound so
+    the real implementation still runs.
+    """
+
+    def __init__(self, cache_path, storage_path, resolved):
+        self._cache_path = cache_path
+        self._storage_path = storage_path
+        self.user = SimpleNamespace(id="account-1")
+        self._resolved = resolved
+        self.resolve_calls = 0
+
+    def profile_paths(self, user_id):
+        self.resolve_calls += 1
+        return self._resolved
+
+
+class AccountDataRemovalTest(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="zapzap-account-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.cache = self._make("cache")
+        self.storage = self._make("storage")
+
+    def _make(self, name):
+        path = os.path.join(self.root, name)
+        os.makedirs(path)
+        with open(os.path.join(path, "session.dat"), "w") as handle:
+            handle.write("session")
+        return path
+
+    def _remove(self, account):
+        WebView.remove_files(account)
+
+    def test_data_of_an_account_disabled_since_startup_is_removed(self):
+        # The profile was never opened, so no paths were captured.
+        account = _Account(None, None, (self.cache, self.storage))
+
+        self._remove(account)
+
+        self.assertFalse(os.path.exists(self.cache))
+        self.assertFalse(os.path.exists(self.storage))
+        self.assertEqual(account.resolve_calls, 1)
+
+    def test_captured_paths_are_used_without_reopening_the_profile(self):
+        account = _Account(self.cache, self.storage, ("/nonexistent", "/nope"))
+
+        self._remove(account)
+
+        self.assertFalse(os.path.exists(self.cache))
+        self.assertFalse(os.path.exists(self.storage))
+        self.assertEqual(account.resolve_calls, 0)
+
+    def test_paths_are_cleared_so_removal_is_not_repeated(self):
+        account = _Account(self.cache, self.storage, (self.cache, self.storage))
+
+        self._remove(account)
+
+        self.assertIsNone(account._cache_path)
+        self.assertIsNone(account._storage_path)
+
+    def test_missing_directories_are_tolerated(self):
+        shutil.rmtree(self.cache)
+        shutil.rmtree(self.storage)
+        account = _Account(self.cache, self.storage, (self.cache, self.storage))
+
+        self._remove(account)  # must not raise
+
+        self.assertFalse(os.path.exists(self.cache))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zapzap/features/browser/web/web_view.py
+++ b/zapzap/features/browser/web/web_view.py
@@ -458,6 +458,14 @@ class WebView(QWebEngineView):
 
         self.whatsapp_page.apply_theme(current_theme, current_color_scheme)
 
+    @staticmethod
+    def profile_paths(user_id) -> tuple[str, str]:
+        """Resolve o cache e o armazenamento de um perfil sem abri-lo."""
+        probe = QWebEngineProfile(str(user_id))
+        paths = (probe.cachePath(), probe.persistentStoragePath())
+        probe.deleteLater()
+        return paths
+
     def remove_files(self):
         """Remove os arquivos de cache e armazenamento persistente do perfil."""
         # TODO: refatorar a lógica de limpeza de cache de contas excluídas
@@ -465,13 +473,19 @@ class WebView(QWebEngineView):
         # inicialização do aplicativo) do que durante a exclusão do perfil.
         # Isso poderia ser feito, talvez, armazenando self._cache_path e
         # self._storage_path por meio do objeto User.
-        if self._cache_path:
-            shutil.rmtree(self._cache_path, ignore_errors=True)
-            self._cache_path = None
+        cache_path = self._cache_path
+        storage_path = self._storage_path
 
-        if self._storage_path:
-            shutil.rmtree(self._storage_path, ignore_errors=True)
-            self._storage_path = None
+        if not cache_path or not storage_path:
+            # Contas desabilitadas desde a inicialização nunca abriram um
+            # perfil, então os caminhos ainda não foram capturados.
+            cache_path, storage_path = self.profile_paths(self.user.id)
+
+        shutil.rmtree(cache_path, ignore_errors=True)
+        shutil.rmtree(storage_path, ignore_errors=True)
+
+        self._cache_path = None
+        self._storage_path = None
 
     def enable_page(self):
         """Ativa a página, configurando novamente."""


### PR DESCRIPTION
Deleting an account can leave its cache and persistent storage behind, including the stored WhatsApp session.

## When it happens

`remove_files()` deletes the two directories recorded in `self._cache_path` and `self._storage_path`. Those are captured in `_configure_profile()`, which only runs when the account is enabled as the `WebView` is built:

```python
if user.enable:
    self._initialize()
```

An account that is disabled when ZapZap starts never opens a profile, so both paths stay `None` and `remove_files()` does nothing at all.

Steps:

1. Disable an account.
2. Restart ZapZap.
3. Delete that account.

Its directories under the WebEngine profile stay on disk, and nothing later cleans them up.

Reproduced with a `WebView` built for a disabled account:

```
_cache_path captured: None
_storage_path captured: None
AFTER remove_files -> cache exists: True | storage exists: True
session file still on disk: True
```

## Regression

6.4.1 covered this case by opening a profile for the disabled account so it could read the paths:

```python
if not self.user.enable:
    self.profile = QWebEngineProfile(str(self.user.id), self)
cache_path = self.profile.cachePath()
```

That handling was dropped in the 7.0 refactor.

## The change

`profile_paths()` resolves an account's cache and storage locations from its id without opening the account, and `remove_files()` falls back to it when the paths were never captured. Accounts that were enabled keep using the paths they already recorded, so nothing changes for them and no second profile is created for a name that is already in use.

I left the existing TODO in place. Moving the cleanup to the next startup is still worth doing, and this does not do that.

## Testing

`tests/test_account_data_removal.py` covers the disabled account case, that captured paths are used without re-resolving, that the paths are cleared afterwards, and that already missing directories do not raise. I checked the first one fails against the current code and passes with the change.

The tests call `remove_files` unbound against a small stand-in rather than building a real `WebView`. `qt_test_case` creates its `QApplication` with an empty argument list, and QtWebEngine aborts without a program name, so a test that constructs a `WebView` cannot run in the suite as it stands. Calling the method unbound still runs the real implementation.

Full suite: 19 passing, 0 failing.
