### PR TITLE
Give the test QApplication a program name so QtWebEngine can start

### DIFF
--- a/tests/qt_test_case.py
+++ b/tests/qt_test_case.py
@@ -35,5 +35,8 @@ class QtTestCase(unittest.TestCase):
     def setUpClass(cls):
         super().setUpClass()
         global _APPLICATION
-        _APPLICATION = QApplication.instance() or QApplication([])
+        # QtWebEngine reads the program name out of argv to initialise
+        # Chromium, and aborts the process when it is missing, so pass one
+        # instead of an empty list.
+        _APPLICATION = QApplication.instance() or QApplication(["zapzap"])
         cls.app = _APPLICATION

--- a/tests/test_account_data_removal.py
+++ b/tests/test_account_data_removal.py
@@ -6,7 +6,10 @@ import tempfile
 import unittest
 from types import SimpleNamespace
 
-import qt_test_case  # noqa: F401  puts the repository root on sys.path
+from PyQt6.QtCore import QCoreApplication, QEvent
+
+from qt_test_case import QtTestCase
+from zapzap.features.accounts.domain.user import User
 from zapzap.features.browser.web.web_view import WebView
 
 
@@ -82,6 +85,37 @@ class AccountDataRemovalTest(unittest.TestCase):
         self._remove(account)  # must not raise
 
         self.assertFalse(os.path.exists(self.cache))
+
+
+class DisabledAccountWebViewTest(QtTestCase):
+    """The same removal, driven through a real WebView."""
+
+    def test_data_is_removed_for_an_account_disabled_since_startup(self):
+        user = User(id="account-disabled", name="Disabled", enable=False)
+        view = WebView(user=user, page_index=0)
+        self.addCleanup(view.deleteLater)
+
+        # The profile was never opened, so the WebView holds no paths.
+        self.assertIsNone(view._cache_path)
+        self.assertIsNone(view._storage_path)
+
+        cache, storage = WebView.profile_paths(user.id)
+        # profile_paths schedules its probe with deleteLater, which only runs
+        # on an event loop turn. Release it before remove_files opens a second
+        # profile under the same name.
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+
+        for path in (cache, storage):
+            os.makedirs(path, exist_ok=True)
+        session = os.path.join(storage, "session.dat")
+        with open(session, "w") as handle:
+            handle.write("session")
+
+        view.remove_files()
+
+        self.assertFalse(os.path.exists(cache))
+        self.assertFalse(os.path.exists(storage))
+        self.assertFalse(os.path.exists(session))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A one line change to the harness, but the reasoning behind it is worth writing down, along with the thing it unlocks.

## How this surfaced

While writing the tests for #817 I wanted to build a real `WebView` and check that deleting a disabled account removes its data. The process died instead:

```
Argument list is empty, the program name is not passed to QCoreApplication.
base::CommandLine cannot be properly initialized.
Aborted (core dumped)
```

`QtWebEngine` takes the program name from argv to initialise Chromium. When argv is empty it aborts the process, so this is not a test failure that gets reported. Whatever ran before it passes, and then the run dies partway through with SIGABRT.

`qt_test_case` builds its application with an empty list:

```python
_APPLICATION = QApplication.instance() or QApplication([])
```

Which means nothing WebEngine backed can be covered at all. `WebView`, the profile lifecycle, `PageController`, the download and notification paths that take a page. That is the part of the codebase where the recent bugs have actually been, and it is the part with no reachable tests.

I worked around it in #817 by calling `remove_files` unbound against a stand-in object. That runs the real implementation, but it cannot catch anything about how `WebView` itself is built.

## Narrowing down what was needed

I expected two problems, because importing the window controller earlier had also produced:

```
QtWebEngineWidgets must be imported or Qt.AA_ShareOpenGLContexts must be set
before a QCoreApplication instance is created
```

So I checked them separately, each in its own process:

| setup | result |
| --- | --- |
| empty argv, as today | aborts, exit 134 |
| program name in argv | works |
| program name plus an early `QtWebEngineWidgets` import | works |

Only argv matters here. The import ordering rule takes care of itself, because a test module importing `WebView` pulls in `QtWebEngineWidgets` at import time, and `qt_test_case` does not build the `QApplication` until `setUpClass`. So the import always lands first.

That is why this is one line rather than a restructure of the harness.

## Showing that it works

`tests/test_account_data_removal.py` gains a case that builds a real `WebView` for a disabled account, confirms it holds no profile paths, and checks that `remove_files()` clears the cache, the storage and the session file from disk. It is the same behaviour the existing cases cover, reached through the real object instead of a stand-in.

Running that file:

* before this change: exit code 134, the run aborts partway through
* after: exit code 0, 5 passing

One detail inside the test. `profile_paths()` releases its probe with `deleteLater()`, which needs an event loop turn, so the test flushes deferred deletes before `remove_files()` opens a second profile under the same name. Without that Qt logs "Using the same data path for profile, may corrupt the data". The real deletion path never opens two, this only comes up because the test resolves the paths itself in order to create the directories.

## Suite

20 passing with this change.

One thing to flag that is not caused by this branch. `test_appearance_settings_ui.py::test_visible_button_group_wraps_and_keeps_independent_switches` is flaky, and badly so when the machine is loaded. I measured it 25 times on `main` and 25 times on this branch:

| | failures |
| --- | --- |
| `main` | 15/25 |
| this branch | 13/25 |

So it fails at roughly the same rate either way. The assertion is:

```
AssertionError: <Direction.LeftToRight: 0> != <Direction.TopToBottom: 2>
```

The test resizes a child group directly and then calls `processEvents()` before asserting that the layout wrapped. The parent layout can activate and reset that geometry first, so the direction has not changed yet when the assertion runs. It looks fixable by activating the parent layout before resizing the group, rather than by waiting. Happy to send that separately if you want it, since it is unrelated to this change.
