### PR TITLE
Make the switch group wrap test deterministic

### DIFF
--- a/tests/test_appearance_settings_ui.py
+++ b/tests/test_appearance_settings_ui.py
@@ -3,6 +3,7 @@
 import unittest
 from unittest.mock import patch
 
+from PyQt6.QtGui import QResizeEvent
 from PyQt6.QtWidgets import QApplication, QBoxLayout
 
 from qt_test_case import QtTestCase
@@ -107,15 +108,22 @@ class AppearanceSettingsUiTests(QtTestCase):
                 for index in range(group.layout.count())
             ))
 
-    def test_visible_button_group_wraps_and_keeps_independent_switches(self):
+    @staticmethod
+    def _resize_to_width(widget, width):
+        """Resize and deliver the event without going through the queue.
+
+        The group is nested several layouts deep, so a posted resize races
+        with the parent layout reassigning the geometry.
+        """
+        previous = widget.size()
+        widget.resize(width, previous.height())
+        QApplication.sendEvent(widget, QResizeEvent(widget.size(), previous))
+
+    def test_visible_button_group_wraps_when_narrow(self):
         page = AppearanceSettingsView()
         group = page.csr_visible_buttons_group
-        page.resize(800, 900)
-        page.show()
-        QApplication.processEvents()
 
-        group.resize(600, group.sizeHint().height())
-        QApplication.processEvents()
+        self._resize_to_width(group, 600)
         self.assertEqual(
             group.rows_layout.direction(),
             QBoxLayout.Direction.LeftToRight,
@@ -125,8 +133,7 @@ class AppearanceSettingsUiTests(QtTestCase):
             for row in group.rows
         ))
 
-        group.resize(420, group.sizeHint().height())
-        QApplication.processEvents()
+        self._resize_to_width(group, 420)
         self.assertEqual(
             group.rows_layout.direction(),
             QBoxLayout.Direction.TopToBottom,
@@ -135,6 +142,12 @@ class AppearanceSettingsUiTests(QtTestCase):
             row.maximumWidth() > group.MAX_COLUMN_WIDTH
             for row in group.rows
         ))
+        page.close()
+
+    def test_visible_button_group_keeps_independent_switches(self):
+        page = AppearanceSettingsView()
+        group = page.csr_visible_buttons_group
+
         self.assertIs(
             group.rows[0].checkbox,
             page.csr_show_minimize_checkBox,


### PR DESCRIPTION
`test_visible_button_group_wraps_and_keeps_independent_switches` fails intermittently. On a loaded machine it fails more often than it passes.

```
AssertionError: <Direction.LeftToRight: 0> != <Direction.TopToBottom: 2>
```

I found it while checking that #818 had not broken anything, and measured it 25 times on `main` to be sure that branch was not the cause:

| | failures |
| --- | --- |
| `main` | 15/25 |

## What is racing

`SettingsSwitchGroup` picks its direction from the width carried on the resize event:

```python
def resizeEvent(self, event):
    stacked = event.size().width() < self.STACK_BREAKPOINT
```

The test resizes the group directly and then waits for the event:

```python
group.resize(420, group.sizeHint().height())
QApplication.processEvents()
```

That group is not a top level widget. Its parents are `SettingsSubgroup`, `SettingsCard`, `SettingsSection`, and two more widgets above those, all with layouts. When the page is shown, those layouts activate and post a resize of their own that reassigns the group's geometry back to the width the layout wants. Two resize events are then in flight for the same widget and the last one to arrive sets the direction, so the result depends on how the machine is behaving at that moment.

## What I tried

I measured each option over 25 iterations rather than guessing:

| approach | wrong results |
| --- | --- |
| build the group standalone, no `show()` | 25/25, the resize is never delivered |
| build it standalone and call `show()` | 4/25, still racing with its own show |
| deliver the resize with `sendEvent` | 0/25 |
| the page's real group, resize with `sendEvent` | 0/25 |

The last one keeps the test pointed at the group the page actually builds, so nothing is lost by making it deterministic.

## The change

`_resize_to_width` resizes the widget and hands the event straight to it, so `resizeEvent` runs synchronously at the requested width. Nothing is left sitting in the queue for a layout pass to override, and the assertion runs before any posted resize can be delivered.

I also split the test. The two assertions tying `group.rows[0]` and `group.rows[1]` to the page's checkboxes have nothing to do with resizing, so they are their own test now and the wrap test is only about wrapping.

## Checks

* 25 runs of the file after the change: 0 failures, down from 15.
* The test still catches real breakage. Setting `STACK_BREAKPOINT` to 100 so the group stops wrapping makes it fail, as it should.
* Full suite: 20 passing, run twice.

This is independent of #818 and sits on `main`, so the two can go in either order.
