### PR TITLE
Add a setting to stop notifying about WhatsApp Channel posts

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -171,6 +171,19 @@ seleciona um backend:
 | Windows | backend Windows |
 | macOS | backend macOS |
 
+A fachada também classifica a origem da notificação. O único campo de
+`QWebEngineNotification` que identifica a conversa é o `tag`, publicado pelo
+WhatsApp Web como o JID do chat; o domínio `newsletter` identifica um canal.
+A regra suprime apenas quando todos os JIDs do `tag` são de canal, de modo que
+um `tag` ausente, em outro formato ou que também nomeie uma pessoa preserva a
+notificação em vez de esconder uma mensagem real. O silenciamento por canal
+feito no WhatsApp não chega ao aplicativo, então a preferência é por categoria,
+não por conversa.
+
+O contador de não lidos é independente desse caminho: ele vem do título da
+página em `WebView._on_title_changed` e alimenta a bandeja e o botão da conta.
+Filtrar uma notificação não altera esse número.
+
 Fechamento de uma notificação WebEngine e encerramento do app devem retirar a
 notificação nativa de forma idempotente. A ativação pode carregar tokens Portal
 ou Wayland e dados de inicialização X11. Mudanças nessa área precisam ser

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -78,6 +78,7 @@ documente o que ele protege.
 | `test_appearance_settings_ui.py` | grupos, dependências, layout responsivo, persistência e acessibilidade |
 | `test_appimage_packaging.py` | nome final fornecido ao quick-sharun e ausência de renomeação posterior do AppImage/zsync |
 | `test_browser_page_button_ui.py` | avatar sem número, grayscale de conta desativada, ponto de estado, card, temas, escala e clique |
+| `test_channel_notification_filter.py` | leitura do JID no tag da notificação e supressão apenas de posts de canais |
 | `test_check_box.py` | API, variantes, tamanhos, pintura, temas, tri-state, mouse, teclado e acessibilidade do CheckBox |
 | `test_component_typography.py` | pesos de fonte de primitives, menus, combos, atalhos e tabs |
 | `test_debugging_settings_ui.py` | manutenção, relatórios, informações de runtime, cópia e feedback |
@@ -90,7 +91,7 @@ documente o que ele protege.
 | `test_network_privacy_settings_ui.py` | proxy, credenciais, aplicar/descartar, restauração e WebRTC |
 | `test_notification_sound_setting.py` | mapeamento de som para hints Portal/Freedesktop |
 | `test_notification_window_activation.py` | tokens Portal/Wayland, startup X11, foco e limpeza |
-| `test_notifications_settings_ui.py` | rótulos, dependências, privacidade, som e lembrete de apoio |
+| `test_notifications_settings_ui.py` | rótulos, dependências, privacidade, som, canais e lembrete de apoio |
 | `test_performance_experimental_settings_ui.py` | seção e reinício da decodificação por software |
 | `test_permissions_settings_ui.py` | grupos e ações globais/individuais de permissões |
 | `test_portal_notification_backend.py` | ciclo de vida, falhas, ações e token no backend Portal |
@@ -108,6 +109,7 @@ documente o que ele protege.
 - `test_appearance_settings_ui.py`
 - `test_appimage_packaging.py`
 - `test_browser_page_button_ui.py`
+- `test_channel_notification_filter.py`
 - `test_check_box.py`
 - `test_component_typography.py`
 - `test_debugging_settings_ui.py`

--- a/tests/test_channel_notification_filter.py
+++ b/tests/test_channel_notification_filter.py
@@ -1,0 +1,166 @@
+"""Regression tests for suppressing WhatsApp Channel notifications."""
+
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+from PyQt6.QtCore import QSettings
+
+import qt_test_case  # noqa: F401  puts the repository root on sys.path
+from zapzap.core.config.settings.notifications import NotificationSettings
+from zapzap.core.config.settings_manager import SettingsManager
+from zapzap.features.notifications.notification_service import (
+    NotificationService,
+    is_channel_notification,
+)
+
+
+class FakeNotification:
+    """The part of QWebEngineNotification the facade reads."""
+
+    def __init__(self, tag=""):
+        self._tag = tag
+
+    def tag(self):
+        return self._tag
+
+    def title(self):
+        return "Sender"
+
+    def message(self):
+        return "Message body"
+
+
+class FakePage:
+
+    def __init__(self, user_id=1):
+        self.user = MagicMock(id=user_id)
+
+
+class ChannelTagTests(unittest.TestCase):
+    """A Channel is recognized by the JID domain WhatsApp uses for it."""
+
+    def test_channel_jid_is_recognized(self):
+        self.assertTrue(
+            is_channel_notification(
+                FakeNotification("120363000000000000@newsletter")
+            )
+        )
+
+    def test_a_message_key_naming_only_a_channel_is_recognized(self):
+        # Some notifications identify a message instead of a chat, joining the
+        # fields of its key with "_".
+        self.assertTrue(
+            is_channel_notification(
+                FakeNotification(
+                    "false_120363000000000000@newsletter_3EB0C767D26A"
+                )
+            )
+        )
+
+    def test_the_domain_is_matched_regardless_of_case(self):
+        self.assertTrue(
+            is_channel_notification(FakeNotification("1203@NEWSLETTER"))
+        )
+
+    def test_people_groups_and_status_are_not_channels(self):
+        for tag in (
+            "5511999999999@c.us",
+            "5511999999999@s.whatsapp.net",
+            "5511999999999@lid",
+            "120363000000000000@g.us",
+            "status@broadcast",
+        ):
+            with self.subTest(tag=tag):
+                self.assertFalse(
+                    is_channel_notification(FakeNotification(tag))
+                )
+
+    def test_a_domain_that_only_starts_with_the_channel_one_is_not_a_channel(
+        self,
+    ):
+        self.assertFalse(
+            is_channel_notification(FakeNotification("1203@newsletterbar"))
+        )
+
+    def test_a_tag_naming_a_person_beside_a_channel_is_kept(self):
+        self.assertFalse(
+            is_channel_notification(
+                FakeNotification(
+                    "false_120363000000000000@newsletter_3EB0_5511@lid"
+                )
+            )
+        )
+
+    def test_an_unrecognized_tag_is_never_treated_as_a_channel(self):
+        for tag in (
+            "",
+            "newsletter",
+            "@newsletter",
+            "1203@",
+            "wa-web-call-active",
+            "Some Channel",
+        ):
+            with self.subTest(tag=tag):
+                self.assertFalse(
+                    is_channel_notification(FakeNotification(tag))
+                )
+
+
+class ChannelNotificationFilterTests(unittest.TestCase):
+    """The preference decides whether a Channel post reaches the backend."""
+
+    CHANNEL = "120363000000000000@newsletter"
+    PERSON = "5511999999999@c.us"
+
+    def setUp(self):
+        self._previous_settings = SettingsManager._settings
+        self._previous_backend = NotificationService._backend
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        SettingsManager._settings = QSettings(
+            str(Path(self._temporary_directory.name) / "notifications.ini"),
+            QSettings.Format.IniFormat,
+        )
+        self.backend = MagicMock()
+        NotificationService._backend = self.backend
+
+    def tearDown(self):
+        SettingsManager._settings = self._previous_settings
+        NotificationService._backend = self._previous_backend
+        self._temporary_directory.cleanup()
+
+    def _notify(self, tag):
+        NotificationService().notify(FakePage(), FakeNotification(tag))
+
+    def test_channel_updates_are_delivered_by_default(self):
+        self.assertTrue(NotificationSettings().channel_updates)
+
+        self._notify(self.CHANNEL)
+
+        self.backend.notify.assert_called_once()
+
+    def test_disabling_the_preference_drops_channel_posts(self):
+        NotificationSettings().channel_updates = False
+
+        self._notify(self.CHANNEL)
+
+        self.backend.notify.assert_not_called()
+
+    def test_disabling_the_preference_keeps_personal_messages(self):
+        NotificationSettings().channel_updates = False
+
+        self._notify(self.PERSON)
+
+        self.backend.notify.assert_called_once()
+
+    def test_an_unrecognized_tag_is_delivered_even_when_disabled(self):
+        NotificationSettings().channel_updates = False
+
+        self._notify("")
+
+        self.backend.notify.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_notifications_settings_ui.py
+++ b/tests/test_notifications_settings_ui.py
@@ -24,12 +24,14 @@ class FakeNotificationsSettingsModel:
         name=True,
         message=True,
         sound=True,
+        channel_updates=True,
     ):
         self.enabled = enabled
         self.show_photo = photo
         self.show_name = name
         self.show_message_preview = message
         self.sound = sound
+        self.channel_updates = channel_updates
         self.donation_message_enabled = False
 
 
@@ -60,6 +62,10 @@ class NotificationsSettingsUiTests(QtTestCase):
         self.assertEqual(page.show_name.title_label.text(), "Contact name")
         self.assertEqual(page.show_msg.title_label.text(), "Message preview")
         self.assertEqual(page.sound.title_label.text(), "Notification sound")
+        self.assertEqual(
+            page.channel_updates.title_label.text(),
+            "Channel updates",
+        )
         self.assertEqual(
             page.donationMessage.title_label.text(),
             "Support reminders",
@@ -123,12 +129,43 @@ class NotificationsSettingsUiTests(QtTestCase):
         page.sound.checkbox.setChecked(True)
         self.assertTrue(model.sound)
 
+    def test_channel_updates_switch_persists_the_preference(self):
+        page, model = self._controller(channel_updates=True)
+
+        page.channel_updates.checkbox.setChecked(False)
+        self.assertFalse(model.channel_updates)
+
+        page.channel_updates.checkbox.setChecked(True)
+        self.assertTrue(model.channel_updates)
+
     def test_privacy_presets_leave_the_notification_sound_alone(self):
         page, model = self._controller(sound=True)
 
         page.maximum_privacy_action.trigger()
 
         self.assertTrue(model.sound)
+
+    def test_privacy_presets_leave_channel_updates_alone(self):
+        page, model = self._controller(channel_updates=True)
+
+        page.maximum_privacy_action.trigger()
+
+        self.assertTrue(model.channel_updates)
+        self.assertNotIn(
+            page.channel_updates,
+            page.notification_content_rows,
+        )
+
+    def test_channel_updates_follows_the_master_switch(self):
+        page, _model = self._controller(enabled=False)
+
+        self.assertFalse(page.channel_updates.isEnabled())
+        self.assertFalse(page.sources_header.isEnabled())
+
+        page.notify_groupBox.checkbox.setChecked(True)
+
+        self.assertTrue(page.channel_updates.isEnabled())
+        self.assertTrue(page.sources_header.isEnabled())
 
     def test_privacy_presets_update_existing_switch_settings(self):
         page, model = self._controller()

--- a/zapzap/core/config/settings/notifications.py
+++ b/zapzap/core/config/settings/notifications.py
@@ -13,6 +13,7 @@ class NotificationSettings(BaseSettings):
     _SHOW_NAME = ("notification/show_name", True)
     _SHOW_MESSAGE_PREVIEW = ("notification/show_msg", True)
     _SOUND = ("notification/sound", True)
+    _CHANNEL_UPDATES = ("notification/channel_updates", True)
     # This legacy key stores whether reminders are hidden, despite its name.
     _DONATION_MESSAGE_HIDDEN = ("notification/donation_message", False)
 
@@ -55,6 +56,15 @@ class NotificationSettings(BaseSettings):
     @sound.setter
     def sound(self, value: bool) -> None:
         self._set_bool(self._SOUND, value)
+
+    @property
+    def channel_updates(self) -> bool:
+        """Whether posts from followed WhatsApp Channels may notify."""
+        return self._get_bool(self._CHANNEL_UPDATES)
+
+    @channel_updates.setter
+    def channel_updates(self, value: bool) -> None:
+        self._set_bool(self._CHANNEL_UPDATES, value)
 
     @property
     def donation_message_enabled(self) -> bool:

--- a/zapzap/features/notifications/notification_service.py
+++ b/zapzap/features/notifications/notification_service.py
@@ -8,6 +8,7 @@ import logging
 
 from PyQt6.QtWebEngineCore import QWebEngineNotification
 
+from zapzap.core.config.settings.notifications import NotificationSettings
 from zapzap.core.config.settings_manager import SettingsManager
 from zapzap import __appname__
 
@@ -28,6 +29,46 @@ def is_flatpak() -> bool:
     return Path("/.flatpak-info").exists()
 
 
+# WhatsApp addresses every chat with a JID, "user@domain", whose domain says
+# what kind of chat it is: "c.us" or "lid" for a person, "g.us" for a group,
+# "newsletter" for a Channel, "broadcast" for status. WhatsApp Web publishes
+# that JID as the tag of the notification it raises, and the tag is the only
+# field QWebEngineNotification carries that identifies where the message came
+# from: there is no access to the data or silent options of the underlying web
+# notification.
+#
+# The tag is the chat JID on its own, except that some notifications identify
+# a single message instead, joining the fields of a message key with "_". Both
+# forms are read the same way, by looking at the domain of every JID in the
+# tag. If WhatsApp Web changes the format, this is written in its
+# WAWebMsgNotification, WAWebBaseNotificationBanner and WAWebWid modules.
+CHANNEL_JID_DOMAIN = "newsletter"
+
+
+def _jid_domains(tag: str) -> list[str]:
+    """The domain of every JID the tag is built from, lowercased."""
+    domains = []
+    for token in tag.lower().split("_"):
+        user, separator, domain = token.partition("@")
+        if separator and user and domain:
+            domains.append(domain)
+    return domains
+
+
+def is_channel_notification(notification: QWebEngineNotification) -> bool:
+    """Whether a notification announces a post from a WhatsApp Channel.
+
+    Only a tag built entirely out of Channel JIDs counts, so a tag that names
+    no chat, that WhatsApp Web publishes in an unknown format, or that names a
+    person alongside a Channel, leaves the notification visible instead of
+    silently hiding a real message.
+    """
+    domains = _jid_domains(notification.tag() or "")
+    return bool(domains) and all(
+        domain == CHANNEL_JID_DOMAIN for domain in domains
+    )
+
+
 class NotificationService:
     """
     Fachada única para notificações.
@@ -43,6 +84,7 @@ class NotificationService:
             NotificationService._backend = self._select_backend()
 
         self.backend = NotificationService._backend
+        self.settings = NotificationSettings()
 
     # ------------------------------------------------------------------
     # Backend selection
@@ -94,6 +136,12 @@ class NotificationService:
 
         if not SettingsManager.get(
             f"{page.user.id}/notification", True
+        ):
+            return
+
+        if (
+            not self.settings.channel_updates
+            and is_channel_notification(notification)
         ):
             return
 

--- a/zapzap/features/settings/pages/notifications/controller.py
+++ b/zapzap/features/settings/pages/notifications/controller.py
@@ -22,14 +22,16 @@ class NotificationsSettingsController(NotificationsSettingsView):
         self.show_name.checkbox.setChecked(self.model.show_name)
         self.show_msg.checkbox.setChecked(self.model.show_message_preview)
         self.sound.checkbox.setChecked(self.model.sound)
+        self.channel_updates.checkbox.setChecked(self.model.channel_updates)
         self.donationMessage.checkbox.setChecked(
             self.model.donation_message_enabled
         )
 
     def _sync_notification_controls(self):
         enabled = self.notify_groupBox.checkbox.isChecked()
-        for row in self.notification_content_rows:
+        for row in self.notification_content_rows + self.notification_source_rows:
             row.setEnabled(enabled)
+        self.sources_header.setEnabled(enabled)
         self.privacy_presets_button.setEnabled(enabled)
 
     def _connect_signals(self):
@@ -47,6 +49,9 @@ class NotificationsSettingsController(NotificationsSettingsView):
         )
         self.sound.checkbox.toggled.connect(
             self._handle_toggle_sound
+        )
+        self.channel_updates.checkbox.toggled.connect(
+            self._handle_toggle_channel_updates
         )
         self.donationMessage.checkbox.toggled.connect(
             self._handle_toggle_donation_message
@@ -87,6 +92,9 @@ class NotificationsSettingsController(NotificationsSettingsView):
 
     def _handle_toggle_sound(self, is_enabled: bool):
         self.model.sound = is_enabled
+
+    def _handle_toggle_channel_updates(self, is_enabled: bool):
+        self.model.channel_updates = is_enabled
 
     def _handle_toggle_donation_message(self, is_enabled: bool):
         self.model.donation_message_enabled = is_enabled

--- a/zapzap/features/settings/pages/notifications/model.py
+++ b/zapzap/features/settings/pages/notifications/model.py
@@ -28,6 +28,15 @@ class NotificationsSettingsModel:
         self._settings.sound = value
 
     @property
+    def channel_updates(self) -> bool:
+        """Whether posts from followed WhatsApp Channels may notify."""
+        return self._settings.channel_updates
+
+    @channel_updates.setter
+    def channel_updates(self, value: bool) -> None:
+        self._settings.channel_updates = value
+
+    @property
     def show_photo(self) -> bool:
         """Whether contact photos are shown in notifications."""
         return self._settings.show_photo

--- a/zapzap/features/settings/pages/notifications/view.py
+++ b/zapzap/features/settings/pages/notifications/view.py
@@ -6,6 +6,7 @@ from PyQt6.QtWidgets import QHBoxLayout, QMenu, QVBoxLayout, QWidget
 from zapzap.ui.components import (
     SettingsCard,
     SettingsPage,
+    SettingsSubgroupHeader,
     SettingsSwitchRow,
 )
 from zapzap.ui.primitives import Button, Label
@@ -65,11 +66,28 @@ class NotificationsSettingsView(SettingsPage):
             self.show_msg,
             self.sound,
         )
-        for row in self.notification_content_rows:
+        # Which chats may notify is a separate question from what a
+        # notification is allowed to show, and the privacy presets in the
+        # header only ever touch the latter.
+        self.sources_header = SettingsSubgroupHeader(
+            _("Which chats notify"),
+        )
+        self.channel_updates = SettingsSwitchRow(
+            _("Channel updates"),
+            _(
+                "Show a notification when a channel you follow posts. "
+                "WhatsApp does not tell ZapZap which channels you muted, so "
+                "this covers all of them."
+            ),
+        )
+        self.notification_source_rows = (self.channel_updates,)
+        for row in self.notification_content_rows + self.notification_source_rows:
             self._configure_accessibility(row)
         card.add_group(
             self.notify_groupBox,
-            self.notification_content_rows,
+            self.notification_content_rows + (
+                self.sources_header,
+            ) + self.notification_source_rows,
             child_dividers=True,
         )
         section.layout().addWidget(card)


### PR DESCRIPTION
This is a workaround for #830 rather than a fix, so I would not close that issue with it. The last section says why.

## The report

Channels followed with notifications turned off still raise a desktop notification for every new post.

## Where the notification comes from

`WebView._configure_profile()` hands WhatsApp Web's notifications to `NotificationService.notify()` through `setNotificationPresenter`. WhatsApp Web decides on its own which notifications to raise, and ZapZap only decides whether to show what arrives. WhatsApp Web does have a mute pipeline, but the mute state of a channel never reaches the desktop app, so from this side every channel post looks like any other message.

What we get is a `QWebEngineNotification`, and it carries very little:

```
title()  message()  origin()  icon()  tag()  language()  direction()
```

There is no `data` and no `silent`. The only field that says anything about where the message came from is `tag()`.

## What the tag holds

WhatsApp addresses every chat with a JID, `user@domain`, and the domain says what kind of chat it is. `c.us` or `lid` for a person, `g.us` for a group, `broadcast` for status, `newsletter` for a channel. WhatsApp Web publishes that JID as the notification tag.

Some notifications identify a single message instead of a chat, joining the fields of a message key with `_`, like `false_120363...@newsletter_3EB0C767D26A`. Both forms are read the same way here, by looking at the domain of every JID in the tag.

I checked that QtWebEngine passes the tag through untouched, using a page that raises notifications against a presenter that prints what it receives:

| JS `new Notification(...)` | `QWebEngineNotification.tag()` |
| --- | --- |
| `{tag: "120363000000000000@newsletter"}` | `'120363000000000000@newsletter'` |
| `{tag: "5511999999999@c.us"}` | `'5511999999999@c.us'` |
| no tag | `''` |

The other half I could not check. There is no WhatsApp account on this checkout, so I never saw the tag of a real channel post. If you want to confirm before merging it takes about a minute. Run:

```
QTWEBENGINE_REMOTE_DEBUGGING=9222 python run.py
```

then in `chrome://inspect`, before a channel posts:

```js
const N = window.Notification;
window.Notification = new Proxy(N, {
  construct(t, a) { console.log('NOTIF', JSON.stringify(a[1])); return new t(...a); }
});
```

If there is no `@newsletter` JID in the tag then the switch will do nothing, and this is not worth taking.

## The change

A "Channel updates" switch on the notifications page. When it is off, `NotificationService` drops a notification whose tag names only channels.

The rule sits in the facade rather than in the four backends, following `docs/maintenance.md` ("Aplique regras comuns em `NotificationService`"). It returns without touching the notification, like the three early returns already there.

### Reading the tag as JIDs rather than as text

`"@newsletter" in tag` would have been shorter, but it is a substring test on a string we do not own. `foo@newsletterbar` matches it, and a real message gets dropped. So every `_` separated token is parsed as `user@domain`, and the notification is suppressed only when at least one JID parsed and all of them are channels.

That leans one way on purpose. A tag naming nothing, a tag in a format this does not recognise, and a tag naming a person next to a channel all leave the notification visible. Hiding a real message would be worse than the bug I am working around. `tests/test_channel_notification_filter.py` covers the whole table, adversarial cases included.

### Where the switch sits

Under its own "Which chats notify" heading rather than among the switches above it. Those answer what a notification may show, and the Privacy presets in the section header drive them. This one answers which chats may notify at all. Keeping the two apart means a later change to `_apply_privacy_preset()` cannot start silencing channels by accident, and there is a test for that.

## What this does not fix

It is all or nothing. WhatsApp does not tell the desktop app which channels you muted, so the switch covers every channel you follow, not only the muted ones. The description on the switch says as much.

It does not change the unread counter either. That number comes from the page title in `WebView._on_title_changed` and feeds the tray and the account button, a path the notification pipeline never touches, so a silenced channel still bumps the badge.

And it depends on a format WhatsApp owns. If Meta changes the tag, the switch quietly stops suppressing. It fails towards showing notifications, and the code comment names the WhatsApp Web modules to re-check.

Given those three I would close #830 as worked around rather than fixed.

## Checks

* `python -m unittest discover -s tests -q`: 231 tests, up from 217 on `main`. The same 7 failures as `main` before the change, all in `test_accounts_settings_ui`, `test_check_box` and `test_segmented_control`, and all focus or keyboard assertions that `offscreen` does not support here. No new ones.
* `python tests/check_unused_code.py --packages-only`: clean.
* `python tests/test_documentation_structure.py -v`: clean.
* `python -m compileall -q zapzap tests tools run.py` and `git diff --check`: clean.
* `python tests/check_unused_code.py --no-fail`: 34 findings, the same 34 as before the change.
* Not run: a real graphical session, and a live WhatsApp account. The tag observation above is the one thing worth doing before this goes in.

## Note on #834

This and #834 are independent and can go in either order, but both add a row to the coverage table in `docs/testing.md`, and the two rows are adjacent, so whichever lands second gets a one hunk conflict there. Resolving it means keeping both edited lines:

```
| `test_notifications_settings_ui.py` | rótulos, dependências, privacidade, som, canais e lembrete de apoio |
| `test_performance_experimental_settings_ui.py` | seção e reinício da decodificação por software e do envio com Ctrl+Enter |
```

I can rebase whichever you would rather take second.
