### PR TITLE
Add a setting to send messages with Ctrl+Enter

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,10 +91,11 @@ documente o que ele protege.
 | `test_notification_sound_setting.py` | mapeamento de som para hints Portal/Freedesktop |
 | `test_notification_window_activation.py` | tokens Portal/Wayland, startup X11, foco e limpeza |
 | `test_notifications_settings_ui.py` | rótulos, dependências, privacidade, som e lembrete de apoio |
-| `test_performance_experimental_settings_ui.py` | seção e reinício da decodificação por software |
+| `test_performance_experimental_settings_ui.py` | seção e reinício da decodificação por software e do envio com Ctrl+Enter |
 | `test_permissions_settings_ui.py` | grupos e ações globais/individuais de permissões |
 | `test_portal_notification_backend.py` | ciclo de vida, falhas, ações e token no backend Portal |
 | `test_segmented_control.py` | seleção exclusiva, sinais, mouse, teclado, acessibilidade, tamanhos, raios e temas |
+| `test_send_with_ctrl_enter.py` | padrão e persistência da preferência, injeção condicional do script e troca de Enter por Ctrl+Enter apenas na caixa de mensagem |
 | `test_settings_card.py` | divisores e grupos do card compartilhado em `ui.components` |
 | `test_settings_radio_group.py` | divisores do grupo de rádio em `ui.components` |
 | `test_software_video_decoding.py` | flag Chromium, persistência, padrão e ordem do bootstrap |
@@ -125,6 +126,7 @@ documente o que ele protege.
 - `test_permissions_settings_ui.py`
 - `test_portal_notification_backend.py`
 - `test_segmented_control.py`
+- `test_send_with_ctrl_enter.py`
 - `test_settings_card.py`
 - `test_settings_radio_group.py`
 - `test_software_video_decoding.py`

--- a/tests/test_performance_experimental_settings_ui.py
+++ b/tests/test_performance_experimental_settings_ui.py
@@ -35,3 +35,29 @@ class PerformanceExperimentalSettingsUiTests(QtTestCase):
             page.restart_bar.restart_kind,
             SettingsRestartBar.APPLICATION,
         )
+
+    def test_send_with_ctrl_enter_sits_with_the_other_web_behavior_rows(self):
+        page = PerformanceExperimentalSettingsController()
+
+        self.assertEqual(
+            page.send_with_ctrl_enter_row.title_label.text(),
+            "Send messages with Ctrl+Enter",
+        )
+        self.assertIn(
+            "new line",
+            page.send_with_ctrl_enter_row.description_label.text(),
+        )
+        self.assertTrue(page.send_with_ctrl_enter.toolTip())
+        self.assertFalse(page.send_with_ctrl_enter.isChecked())
+
+        page.send_with_ctrl_enter.click()
+
+        self.assertTrue(
+            page.model.get_boolean_setting("send_with_ctrl_enter")
+        )
+        # The script is inserted while the profile is built, so rebuilding the
+        # interface is enough; the whole process does not have to restart.
+        self.assertEqual(
+            page.restart_bar.restart_kind,
+            SettingsRestartBar.INTERFACE,
+        )

--- a/tests/test_send_with_ctrl_enter.py
+++ b/tests/test_send_with_ctrl_enter.py
@@ -1,0 +1,322 @@
+"""Regression tests for sending a message with Ctrl+Enter instead of Enter."""
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+from PyQt6 import sip
+from PyQt6.QtCore import QEventLoop, QSettings, QTimer, QUrl
+from PyQt6.QtWebEngineCore import (
+    QWebEnginePage,
+    QWebEngineProfile,
+    QWebEngineScript,
+)
+
+from qt_test_case import QtTestCase
+from zapzap.core.config.settings.performance import PerformanceSettings
+from zapzap.core.config.settings_manager import SettingsManager
+from zapzap.features.browser.web.web_view import WebView
+
+
+SCRIPT_NAME = "send_with_ctrl_enter"
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "zapzap"
+    / "features"
+    / "browser"
+    / "web"
+    / "scripts"
+    / f"{SCRIPT_NAME}.js"
+)
+
+# The composer and the media caption box sit in the footer; the chat list
+# search does not. Only the containment matters to the script, so the markup
+# stays minimal.
+PAGE = """
+<!doctype html><html><body>
+<header><div id="search" contenteditable="true" role="textbox"></div></header>
+<div id="side">
+  <footer><div id="side-search" contenteditable="true" role="textbox"></div></footer>
+</div>
+<footer>
+  <div id="composer" contenteditable="true" role="textbox"></div>
+  <div id="plain" contenteditable="true"></div>
+</footer>
+<script>
+// Stands in for WhatsApp Web, which registers its handlers after the script
+// ZapZap injects at document creation.
+window.seen = null;
+document.addEventListener('keydown', function (e) {
+  if (e.key !== 'Enter') return;
+  // A handler may read a modifier either way, so both are recorded: the
+  // script has to leave the event agreeing with itself.
+  window.seen = {
+    ctrl: e.ctrlKey, shift: e.shiftKey, meta: e.metaKey,
+    ctrlState: e.getModifierState('Control'),
+    shiftState: e.getModifierState('Shift'),
+    metaState: e.getModifierState('Meta'),
+  };
+});
+function press(id, options) {
+  window.seen = null;
+  var target = document.getElementById(id);
+  target.focus();
+  target.dispatchEvent(new KeyboardEvent('keydown', Object.assign(
+    {key: 'Enter', bubbles: true, cancelable: true}, options)));
+  return JSON.stringify(window.seen);
+}
+</script>
+</body></html>
+"""
+
+
+class _Scripts:
+
+    def __init__(self):
+        self.inserted = []
+
+    def insert(self, script):
+        self.inserted.append(script)
+
+
+class _Profile:
+
+    def __init__(self):
+        self._scripts = _Scripts()
+
+    def scripts(self):
+        return self._scripts
+
+
+class _WebView:
+    """Stands in for a WebView, exposing only what the installer touches.
+
+    Instantiating a real WebView opens a QtWebEngine profile for an account,
+    which the installers are not being tested through.
+    """
+
+    def __init__(self):
+        self.profile = _Profile()
+
+    _install_document_script = WebView._install_document_script
+
+
+class SendShortcutSettingTests(unittest.TestCase):
+    """The preference keeps Enter sending until someone asks otherwise."""
+
+    def setUp(self):
+        self._previous_settings = SettingsManager._settings
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        self.settings_path = Path(self._temporary_directory.name) / "web.ini"
+        SettingsManager._settings = QSettings(
+            str(self.settings_path),
+            QSettings.Format.IniFormat,
+        )
+
+    def tearDown(self):
+        SettingsManager._settings = self._previous_settings
+        self._temporary_directory.cleanup()
+
+    def _reload_settings(self):
+        SettingsManager._settings.sync()
+        SettingsManager._settings = QSettings(
+            str(self.settings_path),
+            QSettings.Format.IniFormat,
+        )
+        return PerformanceSettings()
+
+    def test_enter_keeps_sending_by_default(self):
+        self.assertFalse(
+            PerformanceSettings().get_boolean_setting(SCRIPT_NAME)
+        )
+
+    def test_activation_and_deactivation_persist_after_reload(self):
+        PerformanceSettings().set_boolean_setting(SCRIPT_NAME, True)
+        self.assertTrue(
+            self._reload_settings().get_boolean_setting(SCRIPT_NAME)
+        )
+
+        PerformanceSettings().set_boolean_setting(SCRIPT_NAME, False)
+        self.assertFalse(
+            self._reload_settings().get_boolean_setting(SCRIPT_NAME)
+        )
+
+
+class SendShortcutInjectionTests(unittest.TestCase):
+    """The script reaches the profile only while the preference is on."""
+
+    def setUp(self):
+        self._previous_settings = SettingsManager._settings
+        self._temporary_directory = tempfile.TemporaryDirectory()
+        SettingsManager._settings = QSettings(
+            str(Path(self._temporary_directory.name) / "web.ini"),
+            QSettings.Format.IniFormat,
+        )
+
+    def tearDown(self):
+        SettingsManager._settings = self._previous_settings
+        self._temporary_directory.cleanup()
+
+    def _install(self):
+        view = _WebView()
+        WebView._install_send_with_ctrl_enter(view)
+        return view.profile.scripts().inserted
+
+    def test_nothing_is_injected_by_default(self):
+        self.assertEqual([], self._install())
+
+    def test_the_script_is_injected_when_the_preference_is_on(self):
+        SettingsManager.set("web/send_with_ctrl_enter", True)
+
+        inserted = self._install()
+
+        self.assertEqual(1, len(inserted))
+        script = inserted[0]
+        self.assertEqual(SCRIPT_NAME, script.name())
+        self.assertEqual(
+            QWebEngineScript.InjectionPoint.DocumentCreation,
+            script.injectionPoint(),
+        )
+        self.assertEqual(
+            QWebEngineScript.ScriptWorldId.MainWorld,
+            script.worldId(),
+        )
+        self.assertEqual(
+            SCRIPT_PATH.read_text(encoding="utf-8"),
+            script.sourceCode(),
+        )
+
+
+class SendShortcutScriptTests(QtTestCase):
+    """The injected script relabels Enter only inside the message box.
+
+    The page below stands in for WhatsApp Web: the script never sends or edits
+    anything itself, it only changes which modifier the handlers downstream
+    see, so a stand-in that records those modifiers is enough to pin the
+    behaviour down.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Off the record, so the test never writes a profile to disk, and
+        # owned by the application, so it outlives every page it creates.
+        cls.profile = QWebEngineProfile(cls.app)
+        script = QWebEngineScript()
+        script.setName(SCRIPT_NAME)
+        script.setInjectionPoint(
+            QWebEngineScript.InjectionPoint.DocumentCreation)
+        script.setRunsOnSubFrames(True)
+        script.setSourceCode(SCRIPT_PATH.read_text(encoding="utf-8"))
+        script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)
+        cls.profile.scripts().insert(script)
+
+    def setUp(self):
+        # QtWebEngine warns, and can crash, when a profile is released while a
+        # page still refers to it, so the page is destroyed with the test.
+        self.page = QWebEnginePage(self.profile, self.profile)
+        self.addCleanup(self._release_page)
+
+        loop = QEventLoop()
+        self.page.loadFinished.connect(lambda ok: loop.quit())
+        self.page.setHtml(PAGE, QUrl("https://web.whatsapp.com/"))
+        QTimer.singleShot(20000, loop.quit)
+        loop.exec()
+
+        # Probe with something the script does not own, so a script that stops
+        # installing fails the assertion below instead of skipping the class.
+        if self._run_js("1 + 1") != 2:
+            self.skipTest("QtWebEngine did not start in this environment")
+
+        self.assertTrue(self._run_js("!!window.__zapzapSendWithCtrlEnterInstalled"))
+
+    def _release_page(self):
+        # deleteLater() is not enough: the profile is released at interpreter
+        # exit and warns if any page still refers to it.
+        sip.delete(self.page)
+        self.page = None
+        self.app.processEvents()
+
+    def _run_js(self, source):
+        loop = QEventLoop()
+        answer = []
+        self.page.runJavaScript(source, lambda value: (answer.append(value),
+                                                       loop.quit()))
+        QTimer.singleShot(20000, loop.quit)
+        loop.exec()
+        return answer[0] if answer else None
+
+    def _press(self, element, **options):
+        seen = self._run_js(
+            f"press({json.dumps(element)}, {json.dumps(options)})"
+        )
+        self.assertIsNotNone(seen, "the key event never reached a handler")
+        seen = json.loads(seen)
+        # A property and its getModifierState() answer must never disagree.
+        self.assertEqual(seen["ctrl"], seen["ctrlState"])
+        self.assertEqual(seen["shift"], seen["shiftState"])
+        self.assertEqual(seen["meta"], seen["metaState"])
+        return {key: seen[key] for key in ("ctrl", "shift", "meta")}
+
+    SEND = {"ctrl": False, "shift": False, "meta": False}
+    NEW_LINE = {"ctrl": False, "shift": True, "meta": False}
+
+    def test_enter_in_the_message_box_becomes_a_new_line(self):
+        self.assertEqual(self.NEW_LINE, self._press("composer"))
+
+    def test_ctrl_enter_in_the_message_box_becomes_a_send(self):
+        self.assertEqual(
+            self.SEND,
+            self._press("composer", ctrlKey=True),
+        )
+
+    def test_command_enter_in_the_message_box_becomes_a_send(self):
+        # Command is the send chord macOS users reach for.
+        self.assertEqual(
+            self.SEND,
+            self._press("composer", metaKey=True),
+        )
+
+    def test_shift_enter_is_left_alone(self):
+        self.assertEqual(
+            self.NEW_LINE,
+            self._press("composer", shiftKey=True),
+        )
+
+    def test_enter_outside_the_composer_still_sends(self):
+        self.assertEqual(self.SEND, self._press("search"))
+
+    def test_a_search_field_in_the_side_panel_still_sends(self):
+        self.assertEqual(self.SEND, self._press("side-search"))
+
+    def test_an_editable_without_the_textbox_role_is_left_alone(self):
+        self.assertEqual(self.SEND, self._press("plain"))
+
+    def test_a_composing_input_method_is_left_alone(self):
+        self.assertEqual(
+            self.SEND,
+            self._press("composer", isComposing=True),
+        )
+
+    def test_enter_is_left_alone_while_a_suggestion_is_highlighted(self):
+        for attribute, value in (
+            ("aria-activedescendant", "emoji-1"),
+            ("aria-expanded", "true"),
+        ):
+            with self.subTest(attribute=attribute):
+                self._run_js(
+                    "document.getElementById('composer').setAttribute"
+                    f"({json.dumps(attribute)}, {json.dumps(value)})"
+                )
+
+                self.assertEqual(self.SEND, self._press("composer"))
+
+                self._run_js(
+                    "document.getElementById('composer').removeAttribute"
+                    f"({json.dumps(attribute)})"
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zapzap/core/config/settings/performance.py
+++ b/zapzap/core/config/settings/performance.py
@@ -34,6 +34,7 @@ class PerformanceSettings(BaseSettings):
         "disable_animations": ("web/disable_animations", False),
         "disable_pinch": ("web/disable_pinch", False),
         "ctrl_arrow_visual_navigation_fix": ("web/ctrl_arrow_visual_navigation_fix", True),
+        "send_with_ctrl_enter": ("web/send_with_ctrl_enter", False),
     }
 
     BOOLEAN_SETTINGS = tuple(_BOOLEAN_SETTINGS)

--- a/zapzap/features/browser/web/scripts/send_with_ctrl_enter.js
+++ b/zapzap/features/browser/web/scripts/send_with_ctrl_enter.js
@@ -1,0 +1,88 @@
+(function () {
+  if (window.__zapzapSendWithCtrlEnterInstalled) {
+    return;
+  }
+
+  window.__zapzapSendWithCtrlEnterInstalled = true;
+
+  // WhatsApp Web already knows both gestures: Enter sends, Shift+Enter starts a
+  // new line. Its message box is a Lexical editor, which tells the two apart by
+  // the Shift modifier alone. Rather than sending or editing anything
+  // ourselves, we relabel the modifiers of the key event before WhatsApp reads
+  // it, so its own handlers do the work: Enter is read as Shift+Enter, and
+  // Ctrl+Enter as Enter.
+  //
+  // The event stays the original trusted one, so a handler that refuses
+  // synthetic events is not a problem. If WhatsApp ever stops reading the
+  // relabelled modifier, its handler treats the key as a send and this option
+  // silently stops working; nothing is inserted twice and no keystroke is
+  // swallowed.
+
+  // A modifier is exposed twice, as a property and through getModifierState,
+  // and the two have to agree: shadowing only the property would leave the
+  // event contradicting itself for any handler that reads the method.
+  function relabel(event, property, modifier, value) {
+    try {
+      Object.defineProperty(event, property, {
+        value: value,
+        configurable: true,
+      });
+      const inherited = event.getModifierState.bind(event);
+      Object.defineProperty(event, 'getModifierState', {
+        value: function (key) {
+          return key === modifier ? value : inherited(key);
+        },
+        configurable: true,
+      });
+    } catch (e) {
+      // Leave the event as it is; WhatsApp keeps its own behaviour.
+    }
+  }
+
+  function messageBox(target) {
+    if (!target || typeof target.closest !== 'function') return null;
+
+    const editable = target.closest('[contenteditable="true"]');
+    if (!editable || editable.getAttribute('role') !== 'textbox') return null;
+
+    // The chat list and the new chat drawer live in the side panel, and their
+    // search fields must keep sending on Enter.
+    if (editable.closest('#side')) return null;
+
+    // The message box, the caption of an outgoing file and the edit box sit in
+    // the composer footer; the search fields do not. Anything we cannot place
+    // is left alone, so a layout this does not recognize turns the option off
+    // rather than breaking a field. Re-check both landmarks against the page
+    // whenever WhatsApp Web changes its markup.
+    if (!editable.closest('footer')) return null;
+
+    return editable;
+  }
+
+  function suggesting(editable) {
+    // Enter picks the highlighted entry while a mention, emoji or command list
+    // is open, and that is not a send. These two attributes are the standard
+    // way a text box says a list is open; WhatsApp Web is expected, but not
+    // confirmed, to use them.
+    return editable.hasAttribute('aria-activedescendant') ||
+      editable.getAttribute('aria-expanded') === 'true';
+  }
+
+  window.addEventListener('keydown', function (e) {
+    // Shift+Enter already starts a new line, and Alt+Enter is not ours.
+    if (e.key !== 'Enter' || e.shiftKey || e.altKey) return;
+    // Let an input method finish composing before Enter means anything.
+    if (e.isComposing || e.keyCode === 229) return;
+
+    const editable = messageBox(e.target);
+    if (!editable || suggesting(editable)) return;
+
+    if (e.ctrlKey || e.metaKey) {
+      // Command is the send chord on macOS, Control everywhere else.
+      relabel(e, 'ctrlKey', 'Control', false);
+      relabel(e, 'metaKey', 'Meta', false);
+    } else {
+      relabel(e, 'shiftKey', 'Shift', true);
+    }
+  }, true); // capture on window, the first stop before WhatsApp's own handlers
+})();

--- a/zapzap/features/browser/web/web_view.py
+++ b/zapzap/features/browser/web/web_view.py
@@ -145,50 +145,49 @@ class WebView(QWebEngineView):
                 "performance/cache_type", "DiskHttpCache")))
 
         self._install_ctrl_arrow_visual_navigation_fix()
+        self._install_send_with_ctrl_enter()
 
         # Instala o handler de crash específico para este WebView
         crash_handler.register_profile(self.profile)
         self._inject_webrtc_shield()
 
+    def _install_document_script(self, name):
+        """Insert scripts/<name>.js into the profile at document creation.
+
+        The preference that gates a script is read while the profile is being
+        built, so turning one on or off only takes effect once the interface
+        is rebuilt.
+        """
+        try:
+            js_path = os.path.join(
+                os.path.dirname(__file__), "scripts", f"{name}.js")
+            with open(js_path, "r", encoding="utf-8") as f:
+                js_code = f.read()
+
+            script = QWebEngineScript()
+            script.setName(name)
+            script.setInjectionPoint(
+                QWebEngineScript.InjectionPoint.DocumentCreation)
+            script.setRunsOnSubFrames(True)
+            script.setSourceCode(js_code)
+            script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)
+            self.profile.scripts().insert(script)
+        except Exception as e:
+            print(f"Error injecting {name}: {e}")
+
     def _install_ctrl_arrow_visual_navigation_fix(self):
         if SettingsManager.get("web/ctrl_arrow_visual_navigation_fix", True):
-            try:
-                base_dir = os.path.dirname(__file__)
-                js_path = os.path.join(
-                    base_dir, "scripts", "ctrl_arrow_visual_navigation_fix.js")
-                with open(js_path, "r", encoding="utf-8") as f:
-                    js_code = f.read()
+            self._install_document_script("ctrl_arrow_visual_navigation_fix")
 
-                script = QWebEngineScript()
-                script.setName("ctrl_arrow_visual_navigation_fix")
-                script.setInjectionPoint(
-                    QWebEngineScript.InjectionPoint.DocumentCreation)
-                script.setRunsOnSubFrames(True)
-                script.setSourceCode(js_code)
-                script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)
-                self.profile.scripts().insert(script)
-            except Exception as e:
-                print(f"Error injecting ctrl_arrow_visual_navigation_fix: {e}")
+    def _install_send_with_ctrl_enter(self):
+        """Trade Enter for Ctrl+Enter when sending a message."""
+        if SettingsManager.get("web/send_with_ctrl_enter", False):
+            self._install_document_script("send_with_ctrl_enter")
 
     def _inject_webrtc_shield(self):
         """Injeta script para prevenir vazamento de IP via WebRTC."""
         if SettingsManager.get("privacy/webrtc_shield", False):
-            try:
-                base_dir = os.path.dirname(__file__)
-                js_path = os.path.join(base_dir, "scripts", "webrtc_shield.js")
-                with open(js_path, "r", encoding="utf-8") as f:
-                    js_code = f.read()
-
-                script = QWebEngineScript()
-                script.setName("webrtc_shield")
-                script.setInjectionPoint(
-                    QWebEngineScript.InjectionPoint.DocumentCreation)
-                script.setRunsOnSubFrames(True)
-                script.setSourceCode(js_code)
-                script.setWorldId(QWebEngineScript.ScriptWorldId.MainWorld)
-                self.profile.scripts().insert(script)
-            except Exception as e:
-                print(f"Error injecting WebRTC shield: {e}")
+            self._install_document_script("webrtc_shield")
 
     def _inject_web_theme_controller(self):
         """Injects the JavaScript code for the ZapZap WAWeb Theme Controller and QWebChannel support."""

--- a/zapzap/features/settings/pages/performance_experimental/controller.py
+++ b/zapzap/features/settings/pages/performance_experimental/controller.py
@@ -261,6 +261,14 @@ class PerformanceExperimentalSettingsController(PerformanceExperimentalSettingsV
                 "Restart or reload WhatsApp Web after changing this option."
             )
         )
+        self.send_with_ctrl_enter.setToolTip(
+            _(
+                "Relabels Enter as Shift+Enter in the WhatsApp Web message box, "
+                "so it starts a new line, and Ctrl+Enter as Enter, so it sends.\n"
+                "Search fields keep sending on Enter.\n\n"
+                "Restart or reload WhatsApp Web after changing this option."
+            )
+        )
         self.btn_restore.setToolTip(
             _("Restores all performance settings\nto safe default values.")
         )

--- a/zapzap/features/settings/pages/performance_experimental/view.py
+++ b/zapzap/features/settings/pages/performance_experimental/view.py
@@ -218,6 +218,13 @@ class PerformanceExperimentalSettingsView(SettingsPage):
                 "Use visual word navigation in editable fields to fix RTL text cursor movement."
             ),
         )
+        self.send_with_ctrl_enter_row = SettingsSwitchRow(
+            _("Send messages with Ctrl+Enter"),
+            _(
+                "Enter starts a new line in the message box and Ctrl+Enter "
+                "sends the message."
+            ),
+        )
         self.scroll_animator = self.scroll_animator_row.checkbox
         self.background_throttling = self.background_throttling_row.checkbox
         self.disable_animations = self.disable_animations_row.checkbox
@@ -225,12 +232,14 @@ class PerformanceExperimentalSettingsView(SettingsPage):
         self.ctrl_arrow_visual_navigation_fix = (
             self.ctrl_arrow_visual_navigation_fix_row.checkbox
         )
+        self.send_with_ctrl_enter = self.send_with_ctrl_enter_row.checkbox
         for row in (
             self.scroll_animator_row,
             self.background_throttling_row,
             self.disable_animations_row,
             self.disable_pinch_row,
             self.ctrl_arrow_visual_navigation_fix_row,
+            self.send_with_ctrl_enter_row,
         ):
             card.add_row(row)
         section.add_card(card)


### PR DESCRIPTION
Closes #832.

WhatsApp Web binds Enter to send and gives you no way to change it, so every line of a multi-line message needs Shift+Enter. This adds the Telegram style alternative: Enter starts a new line, Ctrl+Enter sends.

## Approach

The obvious way to do this is to intercept Enter, insert a newline yourself, and click the send button on Ctrl+Enter. That needs a send button selector, and getting it wrong is expensive, because the send button and the voice note button share a slot. A miss can start recording instead of sending.

None of that turned out to be necessary. WhatsApp Web already knows both gestures, and its message box is a Lexical editor, which tells a new line from a send by the Shift modifier alone. So the script sends nothing and edits nothing. It relabels the modifiers on the key event before WhatsApp reads it:

| the user presses | WhatsApp reads | WhatsApp does |
| --- | --- | --- |
| Enter | Shift+Enter | new line |
| Ctrl+Enter or Command+Enter | Enter | send |
| Shift+Enter | Shift+Enter, untouched | new line |

The listener is on `window` in the capture phase, installed at document creation, so it runs before WhatsApp registers anything. A modifier is exposed twice, as a property and through `getModifierState()`, and the script shadows both. Shadowing only the property leaves the event contradicting itself, and a handler that normalises through the method would still see a plain Enter and send a half written message.

The event stays the original trusted one. Nothing synthetic is dispatched, so a handler that checks `isTrusted` is not a problem, there is no send button to find, and a double send is not possible.

## Scope

The script only touches an editable that carries `role="textbox"`, sits inside the composer `footer`, and is not inside `#side`. Both search fields therefore keep sending on Enter. Anything it cannot place is left alone, so if WhatsApp changes its markup the option quietly stops working rather than breaking a field.

It also passes through Shift+Enter, Alt+Enter, an input method that is still composing (`isComposing` or keyCode 229), and Enter while the text box says a suggestion list is open, so picking a mention or an emoji still works.

## Verification

`tests/test_send_with_ctrl_enter.py` runs the real script in a QtWebEngine page shaped like WhatsApp Web and asserts what a handler downstream sees, including that each modifier property and its `getModifierState()` answer agree.

A synthetic event cannot reach the interesting cases, so I also drove the script with real `QKeyEvent`s through a `QWebEngineView`:

| pressed in | key | handler sees | `isTrusted` |
| --- | --- | --- | --- |
| composer | Enter | `shiftKey: true`, `getModifierState('Shift'): true` | true |
| composer | Ctrl+Enter | `ctrlKey: false`, `getModifierState('Control'): false` | true |
| composer | Shift+Enter | unchanged | true |
| search | Enter | unchanged | true |

The markup itself I could not check. There is no WhatsApp account on this checkout, so `role="textbox"`, `footer`, `#side` and the `aria-activedescendant` and `aria-expanded` suggestion guard are all checked against a page shaped like WhatsApp Web rather than against the real thing. They fail closed, so a wrong guess turns the option off instead of misfiring. The suggestion guard is the weakest of the four, because it is the standard ARIA pattern rather than something I observed. If WhatsApp signals its mention popup some other way, Enter inserts a new line instead of picking the mention while the popup is open. That is a minute in DevTools if you want it settled before merging.

## Where the setting lives

"Web behavior" on the Performance experimental page, next to "Fix Ctrl+Arrow cursor movement". That is the same kind of option, a script injected into the profile that changes how the rendered page handles input, and it uses the same key namespace (`web/`), the same gate and the same restart path.

The gate is read while the profile is built, so the change needs the interface rebuilt. That already works. Toggling the row makes `_update_restart_requirement()` raise `SettingsRestartBar.INTERFACE`, and `restartInterface()` builds new WebViews and new profiles. There is a test for the restart kind.

Two things follow from that placement, and I would rather say them than let you find them. "Restore performance defaults" resets this along with everything else on the page. And someone hunting for a send key option is not going to look under "Performance experimental". If you would rather "Web behavior" became its own page, both keys already live under `web/`, so it is a pure UI move. Happy to do it here or as a follow up.

Off by default, so Enter keeps sending until someone turns it on.

## Also in this change

`_install_ctrl_arrow_visual_navigation_fix()` and `_inject_webrtc_shield()` were the same twenty lines twice, differing only in the script name and the preference gating them. Adding a third copy did not seem right, so they now share `_install_document_script()`. Behaviour is unchanged.

## Checks

* `python -m unittest discover -s tests -q`: 231 tests, up from 217 on `main`. The same 7 failures as `main` before the change, all in `test_accounts_settings_ui`, `test_check_box` and `test_segmented_control`, and all focus or keyboard assertions that `offscreen` does not support here. No new ones.
* `python tests/check_unused_code.py --packages-only`: clean.
* `python tests/test_documentation_structure.py -v`: clean.
* `python -m compileall -q zapzap tests tools run.py` and `git diff --check`: clean.
* `python tests/check_unused_code.py --no-fail`: 34 findings, the same 34 as before the change.
* Not run: a real graphical session, and a live WhatsApp Web session for the markup above.

## Note on #833

This and #833 are independent and can go in either order, but both add a row to the coverage table in `docs/testing.md`, and the two rows are adjacent, so whichever lands second gets a one hunk conflict there. Resolving it means keeping both edited lines:

```
| `test_notifications_settings_ui.py` | rótulos, dependências, privacidade, som, canais e lembrete de apoio |
| `test_performance_experimental_settings_ui.py` | seção e reinício da decodificação por software e do envio com Ctrl+Enter |
```

I can rebase whichever you would rather take second.
