### PR TITLE
Keep the page console messages instead of discarding them

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -201,6 +201,15 @@ versus `system/quit_in_close` e `donation_message_enabled` versus
 Dados e caches seguem `QStandardPaths`. Testes substituem os diretórios XDG por
 temporários; nunca devem usar o perfil real do mantenedor.
 
+Os arquivos de diagnóstico dividem um único diretório, o `dump_dir` do
+`CrashDumpHandler`, exposto pela página de Depuração. Além dos ZIPs de falha e
+do `faulthandler.log`, `PageConsoleLog` grava ali os avisos e erros que a página
+escreve no console, um registro por linha, com rotação em um único arquivo
+anterior. O `CrashDumpHandler` anexa esse log aos dumps. A preferência
+`diagnostics/page_console_log` desliga a captura e apaga o arquivo; o writer
+guarda esse valor em memória, então quem alterá-lo deve avisá-lo por
+`set_enabled()` em vez de contar com uma releitura do `QSettings`.
+
 ## Instrumentação de memória
 
 O benchmark em `tools/memory/` mantém seu processo coordenador limitado à

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -96,6 +96,7 @@ documente o que ele protege.
 | `test_notification_sound_setting.py` | mapeamento de som e tipos dos hints Portal/Freedesktop |
 | `test_notification_window_activation.py` | conexão QtDBus, tokens Portal/Wayland, startup X11, foco e limpeza |
 | `test_notifications_settings_ui.py` | rótulos, dependências, privacidade, som e lembrete de apoio |
+| `test_page_console_log.py` | formato, rotação, preferência e níveis do log de console da página |
 | `test_performance_experimental_settings_ui.py` | seção e reinício da decodificação por software |
 | `test_permissions_settings_ui.py` | grupos e ações globais/individuais de permissões |
 | `test_portal_notification_backend.py` | ciclo de vida, falhas, ações e token no backend Portal |
@@ -136,6 +137,7 @@ documente o que ele protege.
 - `test_notification_sound_setting.py`
 - `test_notification_window_activation.py`
 - `test_notifications_settings_ui.py`
+- `test_page_console_log.py`
 - `test_performance_experimental_settings_ui.py`
 - `test_permissions_settings_ui.py`
 - `test_portal_notification_backend.py`

--- a/tests/test_page_console_log.py
+++ b/tests/test_page_console_log.py
@@ -1,0 +1,145 @@
+"""Regression tests for the on-disk log of page console messages."""
+
+import os
+import shutil
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+import qt_test_case  # noqa: F401  puts the repository root on sys.path
+from zapzap.core.diagnostics.page_console_log import PageConsoleLog
+
+
+class PageConsoleLogTest(unittest.TestCase):
+    def setUp(self):
+        self.root = tempfile.mkdtemp(prefix="zapzap-console-")
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        self.log = PageConsoleLog(self.root)
+        self.log.set_enabled(True)
+
+    def _read(self):
+        with open(self.log.path, encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_a_message_is_appended_with_its_level_and_origin(self):
+        self.log.write("ERROR", "boom", 42, "https://web.whatsapp.com/app.js")
+
+        record = self._read()
+
+        self.assertIn(" ERROR ", record)
+        self.assertIn("https://web.whatsapp.com/app.js:42", record)
+        self.assertTrue(record.endswith("boom\n"))
+
+    def test_the_account_is_recorded_when_given(self):
+        self.log.write("WARNING", "careful", 1, "app.js", "storage-whats")
+
+        self.assertIn("[storage-whats]", self._read())
+
+    def test_a_multiline_message_stays_on_one_line(self):
+        self.log.write("ERROR", "first\nsecond\nthird", 1, "app.js")
+
+        self.assertEqual(len(self._read().splitlines()), 1)
+        self.assertIn("first second third", self._read())
+
+    def test_nothing_is_written_while_disabled(self):
+        self.log.set_enabled(False)
+
+        self.log.write("ERROR", "boom", 1, "app.js")
+
+        self.assertFalse(self.log.path.exists())
+
+    def test_the_directory_is_created_on_demand(self):
+        nested = os.path.join(self.root, "missing", "deeper")
+        log = PageConsoleLog(nested)
+        log.set_enabled(True)
+
+        log.write("ERROR", "boom", 1, "app.js")
+
+        self.assertTrue(log.path.exists())
+
+    def test_the_file_rotates_once_it_reaches_the_cap(self):
+        log = PageConsoleLog(self.root, max_bytes=200)
+        log.set_enabled(True)
+
+        for index in range(50):
+            log.write("ERROR", f"message {index}", index, "app.js")
+
+        self.assertTrue(log.rotated_path.exists())
+        self.assertLess(log.path.stat().st_size, 200)
+        # A rotação preserva exatamente um arquivo anterior.
+        self.assertEqual(
+            sorted(os.listdir(self.root)),
+            [PageConsoleLog.FILE_NAME, PageConsoleLog.ROTATED_FILE_NAME],
+        )
+
+    def test_an_unwritable_directory_is_survivable(self):
+        log = PageConsoleLog(os.path.join(self.root, "denied"))
+        log.set_enabled(True)
+        os.makedirs(log.path.parent, exist_ok=True)
+        os.chmod(log.path.parent, 0o500)
+        self.addCleanup(os.chmod, log.path.parent, 0o700)
+
+        log.write("ERROR", "boom", 1, "app.js")  # must not raise
+
+        self.assertFalse(log.path.exists())
+
+    def test_clear_removes_both_files(self):
+        log = PageConsoleLog(self.root, max_bytes=200)
+        log.set_enabled(True)
+        for index in range(50):
+            log.write("ERROR", f"message {index}", index, "app.js")
+
+        log.clear()
+
+        self.assertFalse(log.path.exists())
+        self.assertFalse(log.rotated_path.exists())
+
+
+class PageControllerConsoleRoutingTest(unittest.TestCase):
+    """Exercise the real handler without building a QtWebEngine page."""
+
+    def setUp(self):
+        from PyQt6.QtWebEngineCore import QWebEnginePage
+        from zapzap.features.browser.web import page_controller
+
+        self.levels = QWebEnginePage.JavaScriptConsoleMessageLevel
+        self.module = page_controller
+        self.written = []
+
+        original = page_controller.page_console_log
+        page_controller.page_console_log = SimpleNamespace(
+            write=lambda *args: self.written.append(args)
+        )
+        self.addCleanup(
+            setattr, page_controller, "page_console_log", original
+        )
+
+    def _emit(self, level):
+        page = SimpleNamespace(
+            user_id="storage-whats",
+            _CONSOLE_LEVELS=self.module.PageController._CONSOLE_LEVELS,
+        )
+        self.module.PageController.javaScriptConsoleMessage(
+            page, level, "boom", 7, "app.js"
+        )
+
+    def test_errors_are_recorded(self):
+        self._emit(self.levels.ErrorMessageLevel)
+
+        self.assertEqual(
+            self.written, [("ERROR", "boom", 7, "app.js", "storage-whats")]
+        )
+
+    def test_warnings_are_recorded(self):
+        self._emit(self.levels.WarningMessageLevel)
+
+        self.assertEqual(self.written[0][0], "WARNING")
+
+    def test_information_messages_are_dropped(self):
+        self._emit(self.levels.InfoMessageLevel)
+
+        self.assertEqual(self.written, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zapzap/core/config/settings/diagnostics.py
+++ b/zapzap/core/config/settings/diagnostics.py
@@ -1,0 +1,19 @@
+"""Diagnostics settings domain."""
+
+from __future__ import annotations
+
+from zapzap.core.config.settings.base import BaseSettings
+
+
+class DiagnosticsSettings(BaseSettings):
+    """Semantic access to diagnostics settings."""
+
+    _PAGE_CONSOLE_LOG = ("diagnostics/page_console_log", True)
+
+    @property
+    def page_console_log_enabled(self) -> bool:
+        return self._get_bool(self._PAGE_CONSOLE_LOG)
+
+    @page_console_log_enabled.setter
+    def page_console_log_enabled(self, value: bool) -> None:
+        self._set_bool(self._PAGE_CONSOLE_LOG, value)

--- a/zapzap/core/diagnostics/__init__.py
+++ b/zapzap/core/diagnostics/__init__.py
@@ -1,7 +1,12 @@
 from zapzap.core.diagnostics.crash_dump_handler import CrashDumpHandler
+from zapzap.core.diagnostics.page_console_log import PageConsoleLog
 from zapzap import __appname__
 
 crash_handler = CrashDumpHandler(
     app_name=__appname__,
     show_dialog=True
 )
+
+# Compartilha o diretório do crash handler para que a página de Depuração
+# exponha um único lugar com todos os arquivos de diagnóstico.
+page_console_log = PageConsoleLog(crash_handler.dump_dir)

--- a/zapzap/core/diagnostics/crash_dump_handler.py
+++ b/zapzap/core/diagnostics/crash_dump_handler.py
@@ -10,6 +10,7 @@ import faulthandler
 from PyQt6.QtCore import QStandardPaths
 
 from zapzap.core.diagnostics.dialog_dump_handler import DialogDumpHandler
+from zapzap.core.diagnostics.page_console_log import PageConsoleLog
 
 
 from zapzap import __appname__
@@ -53,6 +54,7 @@ class CrashDumpHandler:
         self._profiles = set()
 
         self.faulthandler_path = self.dump_dir / "faulthandler.log"
+        self.page_console_path = self.dump_dir / PageConsoleLog.FILE_NAME
 
         if self.enable_faulthandler:
             self._enable_faulthandler()
@@ -103,6 +105,9 @@ class CrashDumpHandler:
 
             # 4 Dump do faulthandler
             self._attach_faulthandler_log(work_dir)
+
+            # 4.1 Mensagens de console da página
+            self._attach_page_console_log(work_dir)
 
             # 5 Compactação
             self._zip_dump(work_dir, zip_path)
@@ -209,3 +214,14 @@ class CrashDumpHandler:
                 )
         except Exception as e:
             print("Falha ao anexar faulthandler.log:", e)
+
+    def _attach_page_console_log(self, work_dir: Path) -> None:
+        try:
+            if self.page_console_path.exists():
+                target = work_dir / PageConsoleLog.FILE_NAME
+                target.write_text(
+                    self.page_console_path.read_text(errors="ignore"),
+                    encoding="utf-8"
+                )
+        except Exception as e:
+            print(f"Falha ao anexar {PageConsoleLog.FILE_NAME}:", e)

--- a/zapzap/core/diagnostics/page_console_log.py
+++ b/zapzap/core/diagnostics/page_console_log.py
@@ -1,0 +1,100 @@
+"""Registro em disco das mensagens que a página escreve no console."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Optional, Union
+
+from zapzap.core.config.settings.diagnostics import DiagnosticsSettings
+
+
+class PageConsoleLog:
+    """Guarda avisos e erros do WhatsApp Web em um arquivo de tamanho limitado.
+
+    O QtWebEngine descarta a saída de console da página quando o aplicativo não
+    implementa ``javaScriptConsoleMessage``, então um relato de erro nunca podia
+    trazer essa evidência. O arquivo fica ao lado dos relatórios de falha para
+    ser exposto pela página de Depuração e anexado aos dumps já existentes.
+    """
+
+    FILE_NAME = "page-console.log"
+    ROTATED_FILE_NAME = FILE_NAME + ".1"
+    MAX_BYTES = 512 * 1024
+
+    def __init__(
+        self,
+        directory: Union[str, Path],
+        max_bytes: int = MAX_BYTES,
+    ) -> None:
+        self._directory = Path(directory)
+        self._max_bytes = int(max_bytes)
+        self._enabled: Optional[bool] = None
+
+    @property
+    def path(self) -> Path:
+        return self._directory / self.FILE_NAME
+
+    @property
+    def rotated_path(self) -> Path:
+        return self._directory / self.ROTATED_FILE_NAME
+
+    @property
+    def enabled(self) -> bool:
+        """Resolve a preferência uma única vez, fora do caminho de cada escrita."""
+        if self._enabled is None:
+            self._enabled = DiagnosticsSettings().page_console_log_enabled
+        return self._enabled
+
+    def set_enabled(self, value: bool) -> None:
+        self._enabled = bool(value)
+
+    def write(
+        self,
+        level: str,
+        message: str,
+        line: int = 0,
+        source: str = "",
+        account=None,
+    ) -> None:
+        """Acrescenta um registro. Diagnóstico nunca pode derrubar a página."""
+        if not self.enabled:
+            return
+
+        try:
+            self._directory.mkdir(parents=True, exist_ok=True)
+            self._rotate_if_needed()
+            with open(self.path, "a", encoding="utf-8") as handle:
+                handle.write(
+                    self._format(level, message, line, source, account)
+                )
+        except OSError as error:
+            print("Falha ao registrar mensagem do console:", error)
+
+    def clear(self) -> None:
+        for path in (self.path, self.rotated_path):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as error:
+                print("Falha ao remover o log do console:", error)
+
+    def _rotate_if_needed(self) -> None:
+        """Mantém no máximo um arquivo anterior, para limitar o uso de disco."""
+        try:
+            size = self.path.stat().st_size
+        except OSError:
+            return
+
+        if size >= self._max_bytes:
+            os.replace(self.path, self.rotated_path)
+
+    @staticmethod
+    def _format(level, message, line, source, account) -> str:
+        # Uma mensagem por linha: um registro quebrado em várias linhas não
+        # sobrevive ao grep que um relato de erro costuma exigir.
+        text = " ".join(str(message).splitlines())
+        origin = f"{source}:{line}" if source else str(line)
+        timestamp = datetime.now().astimezone().isoformat(timespec="seconds")
+        account_label = f" [{account}]" if account else ""
+        return f"{timestamp} {level}{account_label} {origin} {text}\n"

--- a/zapzap/features/browser/web/page_controller.py
+++ b/zapzap/features/browser/web/page_controller.py
@@ -7,6 +7,7 @@ from PyQt6.QtCore import QUrl
 from PyQt6.QtGui import QDesktopServices
 
 from zapzap import __allowed_hosts__
+from zapzap.core.diagnostics import page_console_log
 from zapzap.features.customizations.addons_manager import AddonsManager
 from zapzap.features.alerts.alert_manager import AlertManager
 from zapzap.features.customizations.customizations_manager import CustomizationsManager
@@ -23,6 +24,13 @@ from gettext import gettext as _
 
 class PageController(QWebEnginePage):
     """Controlador de página para gerenciar eventos e ações personalizadas no QWebEnginePage."""
+
+    # O nível informativo fica de fora: o WhatsApp Web o usa em volume e ele
+    # não carrega o diagnóstico que um relato de erro precisa.
+    _CONSOLE_LEVELS = {
+        QWebEnginePage.JavaScriptConsoleMessageLevel.WarningMessageLevel: "WARNING",
+        QWebEnginePage.JavaScriptConsoleMessageLevel.ErrorMessageLevel: "ERROR",
+    }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -327,5 +335,11 @@ class PageController(QWebEnginePage):
         self.runJavaScript(script)
 
     def javaScriptConsoleMessage(self, level, message, line, sourceID):
-        """ Ignora as mensagens do console """
-        pass
+        """Registra avisos e erros da página; mensagens informativas são ignoradas."""
+        level_name = self._CONSOLE_LEVELS.get(level)
+        if level_name is None:
+            return
+
+        page_console_log.write(
+            level_name, message, line, sourceID, self.user_id
+        )

--- a/zapzap/features/settings/pages/debugging/controller.py
+++ b/zapzap/features/settings/pages/debugging/controller.py
@@ -21,10 +21,15 @@ class DebuggingSettingsController(DebuggingSettingsView):
         self._feedback_timer.setSingleShot(True)
         self._feedback_timer.timeout.connect(self._restore_feedback_text)
         self._configure_signals()
+        self._load_settings()
         self._refresh_debug_logs_ui()
         self._refresh_runtime_environment()
 
+    def _load_settings(self):
+        self.page_console_log.setChecked(self.model.page_console_log_enabled)
+
     def _configure_signals(self):
+        self.page_console_log.clicked.connect(self._handle_page_console_log)
         self.btn_open_debug_logs.clicked.connect(self._handle_open_debug_logs)
         self.btn_diagnostic_open_folder.clicked.connect(self._handle_open_debug_logs)
         self.btn_copy_debug_logs_path.clicked.connect(self._copy_debug_logs_path)
@@ -39,6 +44,10 @@ class DebuggingSettingsController(DebuggingSettingsView):
 
         self.btn_refresh_runtime.clicked.connect(self._refresh_runtime_environment)
         self.btn_copy_runtime.clicked.connect(self._copy_runtime_environment)
+
+    def _handle_page_console_log(self):
+        self.model.page_console_log_enabled = self.page_console_log.isChecked()
+        self._refresh_debug_logs_ui()
 
     def _refresh_debug_logs_ui(self):
         details = self.model.debug_logs_details()

--- a/zapzap/features/settings/pages/debugging/model.py
+++ b/zapzap/features/settings/pages/debugging/model.py
@@ -5,17 +5,34 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from zapzap.core.diagnostics import crash_handler
+from zapzap.core.diagnostics import crash_handler, page_console_log
 from zapzap.core.diagnostics.runtime_environment_debug import RuntimeEnvironmentDebug
+from zapzap.core.config.settings.diagnostics import DiagnosticsSettings
 from zapzap.core.config.settings_manager import SettingsManager
 
 
 class DebuggingSettingsModel:
     """Provides debug log, runtime information, and reset operations."""
 
+    def __init__(self):
+        self.diagnostics_settings = DiagnosticsSettings()
+
     @property
     def debug_logs_dir(self) -> Path:
         return Path(crash_handler.dump_dir)
+
+    @property
+    def page_console_log_enabled(self) -> bool:
+        return self.diagnostics_settings.page_console_log_enabled
+
+    @page_console_log_enabled.setter
+    def page_console_log_enabled(self, value: bool) -> None:
+        self.diagnostics_settings.page_console_log_enabled = value
+        # O writer guarda a preferência para não reler QSettings a cada
+        # mensagem, então a mudança precisa alcançá-lo explicitamente.
+        page_console_log.set_enabled(value)
+        if not value:
+            page_console_log.clear()
 
     def ensure_debug_logs_dir(self) -> Path:
         logs_dir = self.debug_logs_dir

--- a/zapzap/features/settings/pages/debugging/view.py
+++ b/zapzap/features/settings/pages/debugging/view.py
@@ -22,6 +22,7 @@ from zapzap.ui.components import (
     SettingsCard,
     SettingsPage,
     SettingsSection,
+    SettingsSwitchRow,
 )
 from zapzap.ui.primitives import Button, Label
 
@@ -207,6 +208,18 @@ class DebuggingSettingsView(SettingsPage):
             _("Manage files used to diagnose errors."),
         )
         card = SettingsCard()
+
+        self.page_console_log_row = SettingsSwitchRow(
+            _("Record page messages"),
+            _(
+                "Save the warnings and errors WhatsApp Web reports to "
+                "page-console.log, so a bug report can carry them. Turning "
+                "this off also deletes the file."
+            ),
+            parent=card,
+        )
+        self.page_console_log = self.page_console_log_row.checkbox
+        card.add_row(self.page_console_log_row)
 
         path_header = QWidget(card)
         path_layout = QVBoxLayout(path_header)


### PR DESCRIPTION
# Keep the page console messages instead of discarding them

`PageController.javaScriptConsoleMessage` overrode the `QWebEnginePage` hook with `pass`
(`page_controller.py:329-331`), so every warning and error `web.whatsapp.com` wrote to its console was
dropped. That override is the only sink there is: QtWebEngine has nowhere else to put page console
output, so once it returns, the message is gone.

The practical effect shows up in the logout and QR cluster. #355, #425, #494, #653, #669, #745, #765
and now #841 all describe sessions disappearing or the QR spinner never resolving, over about sixteen
months, and not one of them carries client-side evidence. When #653 was closed the stated bar for
reopening was "evidence that the local ZapZap profile or session data is being deleted". A reporter
had no way to produce that, because the one place the page says what went wrong was being thrown away.

## What this changes

Warnings and errors now go to `page-console.log`, one record per line, in the directory the crash
handler already owns and the Debugging page already exposes. So the file is reachable through the
"Open folder" button that exists today, it is removed by the existing "Delete all logs and reports"
action, and `CrashDumpHandler` attaches it to crash dumps next to `faulthandler.log`.

A record looks like this:

```
2026-08-12T14:03:11+01:00 ERROR [storage-whats] https://web.whatsapp.com/app.js:1 Failed to open IndexedDB
```

Multi-line messages are folded onto one line, since a record split across lines does not survive the
`grep` a bug report usually needs. The file rotates once at 512 KB and keeps a single previous copy,
so an app left running for weeks cannot fill a disk.

Information-level messages stay dropped. WhatsApp Web emits them constantly and they carry nothing
worth reading later, so keeping them would only cost disk and bury the records that matter.

## About privacy

Console output can quote page state, so this is a new file on disk with content the user did not
choose. `diagnostics/page_console_log` turns the capture off and deletes the file, from a switch in
Settings, Debugging.

It defaults to on. Off by default would mean the evidence is still missing at the moment somebody
writes their report, which is the problem this is meant to solve. I am happy to flip the default if
you would rather ask reporters to enable it first.

## Tests

`tests/test_page_console_log.py`, 11 tests: record format, the account label, multi-line folding, the
disabled path, directory creation, rotation keeping exactly one previous file, surviving an unwritable
directory, `clear()`, and the level mapping in `PageController.javaScriptConsoleMessage` itself.

```
python -m unittest discover -s tests -q          # 363 tests, OK
python tests/check_unused_code.py --packages-only
python tests/test_documentation_structure.py -v
python -m compileall -q zapzap tests tools run.py
git diff --check
```

All green. Note that the suite needs `QT_QPA_PLATFORM=offscreen` in the environment: `qt_test_case.py`
sets it with `setdefault`, so a value inherited from a Wayland or X11 session wins and several UI tests
then fail on focus and layout. That is a separate thing and I have not touched it here.

This does not fix #841 by itself. It is what makes the next report of #841 answerable.
