### PR TITLE
Run the normal shutdown when the session terminates the app

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,8 +43,23 @@ O caminho principal está em `zapzap/app/application.py`:
 5. inicia tema e constrói a janela principal;
 6. no Flatpak, exporta `org.freedesktop.Application` por D-Bus;
 7. aplica proxy, decide visibilidade inicial e mostra o onboarding se preciso;
-8. no encerramento, remove notificações, para D-Bus e tema e libera páginas
+8. assume SIGINT, SIGTERM e SIGHUP por `TerminationSignalWatcher`;
+9. no encerramento, remove notificações, para D-Bus e tema e libera páginas
    WebEngine explicitamente.
+
+O passo 8 existe porque o aplicativo permanece em segundo plano por padrão e um
+desligamento ou logout o termina por sinal. A disposição padrão do Python mata o
+processo sem desmontar o laço de eventos, então `aboutToQuit` não roda e nada do
+passo 9 acontece. O watcher usa `signal.set_wakeup_fd` sobre um par de sockets,
+porque um handler Python só roda entre bytecodes e o processo ocioso fica
+bloqueado dentro do laço em C++. O primeiro sinal devolve as disposições
+anteriores, mantendo interrompível um encerramento que trave.
+
+`shutdownInterface()` drena os `DeferredDelete` pendentes ao final. Páginas e
+perfis são liberados por `deleteLater()`, e um `DeferredDelete` postado fora de
+um laço de eventos nunca é entregue; sem a drenagem o `QWebEngineProfile`
+sobrevive ao encerramento e o Chromium não descarrega cookies, localStorage e
+IndexedDB, que só são gravados quando o perfil é destruído.
 
 Depois que o event loop começa, `MainWindowController` inicia no máximo uma
 consulta assíncrona de release por execução. `core.update_checker`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -107,6 +107,7 @@ documente o que ele protege.
 | `test_software_video_decoding.py` | flag Chromium, persistência, padrão e ordem do bootstrap |
 | `test_spellcheck_language_picker.py` | migração, seleção múltipla transacional, pesquisa, limite, recentes, menu e perfis WebEngine |
 | `test_system_startup_settings_ui.py` | semântica de fechamento, diálogo nativo e acessibilidade |
+| `test_termination_signals.py` | conversão de SIGTERM em `quit`, restauração dos handlers e segundo sinal |
 | `test_update_checker.py` | versões, política de builds, respostas/falhas assíncronas, metadados seguros e popover acessível compartilhado entre sidebar e Sobre |
 | `test_window_state_restore.py` | ciclo de vida compartilhado, restauração normal, maximizada e fullscreen e destruição segura do host CSR |
 | `test_windows_packaging.py` | matriz nativa x86_64/ARM64, arquitetura do Python e nomes dos executáveis Windows |
@@ -147,6 +148,7 @@ documente o que ele protege.
 - `test_software_video_decoding.py`
 - `test_spellcheck_language_picker.py`
 - `test_system_startup_settings_ui.py`
+- `test_termination_signals.py`
 - `test_update_checker.py`
 - `test_window_state_restore.py`
 - `test_windows_packaging.py`

--- a/tests/test_termination_signals.py
+++ b/tests/test_termination_signals.py
@@ -1,0 +1,88 @@
+"""Regression tests for turning termination signals into a clean Qt quit."""
+
+import os
+import signal
+import time
+import unittest
+from types import SimpleNamespace
+
+from PyQt6.QtCore import QEventLoop
+
+from qt_test_case import QtTestCase
+from zapzap.app.termination_signals import TerminationSignalWatcher
+
+
+class RecordingApp:
+    def __init__(self):
+        self.quit_calls = 0
+
+    def quit(self):
+        self.quit_calls += 1
+
+
+class TerminationSignalWatcherTest(QtTestCase):
+    def setUp(self):
+        super().setUp()
+        self.target = RecordingApp()
+        self.watcher = TerminationSignalWatcher(self.target)
+        self.addCleanup(self.watcher.uninstall)
+
+    def _pump_until_quit(self, timeout=5.0):
+        deadline = time.monotonic() + timeout
+        while self.target.quit_calls == 0 and time.monotonic() < deadline:
+            self.app.processEvents(QEventLoop.ProcessEventsFlag.AllEvents, 20)
+
+    def test_sigterm_quits_instead_of_killing_the_process(self):
+        self.assertTrue(self.watcher.install())
+
+        # Reaching the assertion at all proves the default disposition is gone:
+        # SIG_DFL for SIGTERM would have ended this test process here.
+        os.kill(os.getpid(), signal.SIGTERM)
+        self._pump_until_quit()
+
+        self.assertEqual(self.target.quit_calls, 1)
+
+    def test_the_previous_handlers_are_restored_on_uninstall(self):
+        before = {
+            number: signal.getsignal(number)
+            for number in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP)
+        }
+
+        self.watcher.install()
+        self.watcher.uninstall()
+
+        for number, handler in before.items():
+            self.assertEqual(signal.getsignal(number), handler)
+
+    def test_the_wakeup_descriptor_is_restored_on_uninstall(self):
+        self.watcher.install()
+        self.watcher.uninstall()
+
+        # set_wakeup_fd returns the descriptor it replaced; -1 means the
+        # watcher gave the slot back instead of leaving its socket installed.
+        restored = signal.set_wakeup_fd(-1)
+        self.assertEqual(restored, -1)
+
+    def test_a_second_signal_is_left_to_the_default_disposition(self):
+        self.watcher.install()
+
+        os.kill(os.getpid(), signal.SIGTERM)
+        self._pump_until_quit()
+
+        # A shutdown that hangs has to stay interruptible, so the watcher steps
+        # aside after the signal it acted on.
+        self.assertFalse(self.watcher.installed)
+        self.assertEqual(signal.getsignal(signal.SIGTERM), signal.SIG_DFL)
+
+    def test_installing_twice_is_refused(self):
+        self.assertTrue(self.watcher.install())
+        self.assertFalse(self.watcher.install())
+
+    def test_uninstall_without_install_is_harmless(self):
+        self.watcher.uninstall()  # must not raise
+
+        self.assertFalse(self.watcher.installed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zapzap/app/application.py
+++ b/zapzap/app/application.py
@@ -14,6 +14,7 @@ from zapzap.features.browser.shell.browser_controller import (
     load_webview_factory,
 )
 from zapzap.app.startup_options import apply_startup_options, parse_startup_options
+from zapzap.app.termination_signals import TerminationSignalWatcher
 from zapzap.app.window_lifecycle import ClientSideWindowHost
 from zapzap.core.diagnostics import crash_handler
 from zapzap.assets.icons.tray_icon import TrayIcon
@@ -139,6 +140,11 @@ def main():
         app.aboutToQuit.connect(desktop_application_dbus.stop)
     app.aboutToQuit.connect(ThemeManager.stop)
     app.aboutToQuit.connect(app.shutdownInterface)
+
+    # Um desligamento ou logout termina o processo em segundo plano por sinal, e
+    # nada acima roda quando ele morre pela disposição padrão do Python.
+    termination_signals = TerminationSignalWatcher(app)
+    termination_signals.install()
 
     exit_code = app.exec()
 

--- a/zapzap/app/single_application.py
+++ b/zapzap/app/single_application.py
@@ -3,7 +3,15 @@
 import subprocess
 import sys
 
-from PyQt6.QtCore import Qt, QTextStream, QTimer, pyqtSignal, pyqtSlot
+from PyQt6.QtCore import (
+    QCoreApplication,
+    QEvent,
+    Qt,
+    QTextStream,
+    QTimer,
+    pyqtSignal,
+    pyqtSlot,
+)
 from PyQt6.QtNetwork import QLocalServer, QLocalSocket
 from PyQt6.QtWidgets import QApplication
 
@@ -145,6 +153,13 @@ class SingleApplication(QApplication):
         browser = getattr(self.window, "browser", None)
         if browser:
             browser.shutdown()
+
+        # As páginas e os perfis WebEngine são liberados por deleteLater(), e um
+        # DeferredDelete postado fora de um laço de eventos nunca é entregue.
+        # Sem esta drenagem o QWebEngineProfile sobrevive ao encerramento, e o
+        # Chromium só descarrega cookies, localStorage e IndexedDB quando o
+        # perfil é destruído.
+        QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
 
     def _restart_application_now(self):
         if self.window and hasattr(self.window, "save_window_state"):

--- a/zapzap/app/termination_signals.py
+++ b/zapzap/app/termination_signals.py
@@ -1,0 +1,132 @@
+"""Transforma sinais de término em um encerramento normal do Qt."""
+
+from __future__ import annotations
+
+import signal
+import socket
+
+from PyQt6.QtCore import QObject, QSocketNotifier
+
+
+def _supported_signals():
+    names = ("SIGINT", "SIGTERM", "SIGHUP")
+    return tuple(
+        number
+        for number in (getattr(signal, name, None) for name in names)
+        if number is not None
+    )
+
+
+class TerminationSignalWatcher(QObject):
+    """Encerra pelo caminho normal quando o sistema termina o aplicativo.
+
+    A disposição padrão do Python para SIGTERM mata o processo sem desmontar o
+    laço de eventos do Qt, então `aboutToQuit` não roda e o QtWebEngine nunca
+    descarrega o perfil em disco. Como o ZapZap fica em segundo plano por
+    padrão, é exatamente isso que acontece em todo desligamento ou logout.
+
+    Um handler Python sozinho também não resolve: ele só roda entre bytecodes e
+    o processo passa o tempo ocioso bloqueado dentro do laço de eventos em C++.
+    O par de sockets registrado em `set_wakeup_fd` transforma o sinal em um
+    evento comum de leitura, que acorda o Qt e permite sair pelo mesmo caminho
+    de um "Sair" no menu.
+
+    O primeiro sinal restaura as disposições anteriores, de modo que um segundo
+    sinal volte a encerrar o processo imediatamente e um encerramento travado
+    continue interrompível.
+    """
+
+    def __init__(self, app, signals=None, parent=None):
+        super().__init__(parent)
+        self._app = app
+        self._signals = _supported_signals() if signals is None else tuple(signals)
+        self._previous_handlers = {}
+        self._previous_wakeup_fd = None
+        self._notifier = None
+        self._reader = None
+        self._writer = None
+
+    @property
+    def installed(self) -> bool:
+        return self._notifier is not None
+
+    def install(self) -> bool:
+        """Assume os sinais. Devolve False quando o ambiente não permite."""
+        if self.installed or not self._signals:
+            return False
+
+        try:
+            self._reader, self._writer = socket.socketpair()
+            self._reader.setblocking(False)
+            self._writer.setblocking(False)
+            # set_wakeup_fd exige a thread principal e é o que faz o handler em
+            # C escrever no socket; sem ele o notifier nunca acorda.
+            self._previous_wakeup_fd = signal.set_wakeup_fd(
+                self._writer.fileno()
+            )
+        except (OSError, ValueError):
+            self._close_sockets()
+            return False
+
+        self._notifier = QSocketNotifier(
+            self._reader.fileno(), QSocketNotifier.Type.Read, self
+        )
+        self._notifier.activated.connect(self._on_signal_received)
+
+        for number in self._signals:
+            try:
+                # O handler em si não faz nada: registrá-lo é o que instala o
+                # handler em C que alimenta o socket.
+                self._previous_handlers[number] = signal.signal(
+                    number, self._noop_handler
+                )
+            except (OSError, ValueError):
+                continue
+
+        return True
+
+    def uninstall(self) -> None:
+        """Devolve os sinais a quem os tinha. Seguro de chamar duas vezes."""
+        if self._notifier is not None:
+            self._notifier.setEnabled(False)
+            self._notifier.deleteLater()
+            self._notifier = None
+
+        for number, handler in self._previous_handlers.items():
+            try:
+                signal.signal(number, handler)
+            except (OSError, ValueError, TypeError):
+                continue
+        self._previous_handlers.clear()
+
+        if self._previous_wakeup_fd is not None:
+            try:
+                signal.set_wakeup_fd(self._previous_wakeup_fd)
+            except (OSError, ValueError):
+                pass
+            self._previous_wakeup_fd = None
+
+        self._close_sockets()
+
+    def _on_signal_received(self) -> None:
+        try:
+            self._reader.recv(4096)
+        except OSError:
+            pass
+
+        self.uninstall()
+        self._app.quit()
+
+    @staticmethod
+    def _noop_handler(signum, frame) -> None:
+        """O trabalho acontece no notifier, dentro do laço de eventos."""
+
+    def _close_sockets(self) -> None:
+        for sock in (self._reader, self._writer):
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+        self._reader = None
+        self._writer = None


### PR DESCRIPTION
# Run the normal shutdown when the session terminates the app

ZapZap keeps running in the background by default (`system/quit_in_close` defaults to `False`,
`system.py:15`, and `close_event` hides the window and calls `event.ignore()`,
`window_lifecycle.py:68-77`). So a reboot or a logout does not close a window. It sends SIGTERM to a
live process that is holding every account's `QWebEngineProfile`.

Nothing handles that signal. `git log -S"SIGTERM" --all` and `git log -S"import signal" --all -- zapzap/`
both return zero commits, so this has never been handled. `faulthandler.enable()`
(`crash_dump_handler.py:57-58`) covers SIGSEGV, SIGFPE, SIGABRT, SIGBUS and SIGILL and leaves SIGTERM
at `SIG_DFL`. Python's default disposition ends the process without unwinding the Qt event loop, so
`aboutToQuit` never runs and everything hanging off it is dead code on that path: notifications, D-Bus,
theme, and `shutdownInterface` (`application.py:137-141`). The defensive repeat after `app.exec()`
cannot help either, because `exec()` never returns.

That matters for the profile specifically. Chromium writes cookies, localStorage and IndexedDB when
the profile is destroyed, and Qt documents that a disk-backed profile should be destroyed before the
application exits or its cache and persistent data may not be fully flushed.

## Taking the signal

`TerminationSignalWatcher` takes SIGINT, SIGTERM and SIGHUP and quits through the ordinary path.

A Python-level handler on its own is not enough. Python handlers only run between bytecodes, and an
idle ZapZap sits blocked inside the C++ event loop, so the handler would not run until something else
happened to wake the process. Registering a socketpair through `signal.set_wakeup_fd` turns the signal
into a readable-socket event, which the Qt loop already knows how to wake for. A `QSocketNotifier`
picks it up and calls `quit()`, and from there the shutdown is the same one a menu "Sair" performs.

The first signal restores the previous dispositions before quitting. A second SIGTERM then ends the
process the usual way, so a shutdown that hangs stays interruptible and Ctrl+C keeps working.

Session-manager `commitDataRequest` is deliberately left alone. Qt 6 removed the fallback
session-management switch, and a logout the user then cancels would still have torn the interface
down. SIGTERM is unambiguous and is what actually arrives on current desktops.

## Draining the deferred deletes

`shutdownInterface()` now drains pending `DeferredDelete` events after `browser.shutdown()`.

Pages and profiles are released with `deleteLater()` (`web_view.py:566`), and a `DeferredDelete`
posted outside a running event loop is never delivered. Qt's own documentation for `sendPostedEvents`
says you have to ask for that delivery explicitly if you want deferred deletion outside the loop.
Without it the profile outlives the shutdown it was supposed to be released by, which is the
difference between a flushed session and a lost one.

This also helps the interface restart at `single_application.py:183-187`, where the old profiles were
still queued for deletion while `_create_interface_window()` built new ones on the same storage names.

## Measured

A `QWebEngineProfile` and `QWebEnginePage`, SIGTERM'd 3 seconds in:

| | teardown ran | exit code |
|---|---|---|
| before | no | 143 |
| after | yes | 0 |

## Tests

`tests/test_termination_signals.py`, 6 tests: SIGTERM reaching `quit()` instead of ending the process,
handler restoration, wakeup-descriptor restoration, the second signal falling back to the default
disposition, a refused double install, and `uninstall()` before `install()`.

```
python -m unittest discover -s tests -q          # 358 tests, OK
python tests/check_unused_code.py --packages-only
python tests/test_documentation_structure.py -v
python -m compileall -q zapzap tests tools run.py
git diff --check
```

All green, with `QT_QPA_PLATFORM=offscreen` set in the environment.

## Scope

I would not claim this closes #841. It explains a session lost across a reboot, and the reporter there
gives a reboot as their example, but it does not explain the second half of that report, where the QR
code then spins forever until a reinstall. An empty profile shows a working QR, so something residual
is involved that this does not touch. Worth having on its own terms either way.
