### PR TITLE
fix(browser): avoid reentrant stop during external navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ This mandatory record starts after version 7.4.1. The 7.4.1 entry below is the
 historical baseline; older release summaries remain available in the GitHub
 releases and the AppStream metadata.
 
+## [7.4.4] - In development
+
+### Fixed
+
+- Prevented external conversation links from crashing Qt WebEngine by avoiding
+  a reentrant stop while its navigation request is still being processed.
+
 ## [7.4.3] - 2026-08-30
 
 ### Added
@@ -115,6 +122,7 @@ releases and the AppStream metadata.
 - Improved reliability when ZapZap is closed by the operating system.
 - Included performance improvements.
 
+[7.4.4]: https://github.com/rafatosta/zapzap/compare/7.4.3...HEAD
 [7.4.3]: https://github.com/rafatosta/zapzap/compare/7.4.2...7.4.3
 [7.4.2]: https://github.com/rafatosta/zapzap/compare/7.4.1...7.4.2
 [7.4.1]: https://github.com/rafatosta/zapzap/releases/tag/7.4.1

--- a/tests/test_external_link_lifecycle.py
+++ b/tests/test_external_link_lifecycle.py
@@ -66,7 +66,7 @@ class ExternalLinkLifecycleTests(unittest.TestCase):
             )
             return open_url, opened
 
-    def test_external_page_is_stopped_and_deleted_after_handoff(self):
+    def test_external_page_is_deleted_without_reentrant_stop_after_handoff(self):
         open_url, opened = self._open("https://example.com/path")
 
         self.assertTrue(opened)
@@ -76,10 +76,7 @@ class ExternalLinkLifecycleTests(unittest.TestCase):
             "https://example.com/path",
         )
         self.assertTrue(self.page.property("externalUrlOpened"))
-        self.assertEqual(
-            self.page.triggered_actions,
-            [_ExternalPage.WebAction.Stop],
-        )
+        self.assertEqual(self.page.triggered_actions, [])
         self.assertEqual(self.page.delete_later_calls, 1)
 
     def test_redirect_signal_does_not_reopen_or_dispose_twice(self):
@@ -90,10 +87,7 @@ class ExternalLinkLifecycleTests(unittest.TestCase):
         self.assertFalse(second_result)
         first_open.assert_called_once()
         second_open.assert_not_called()
-        self.assertEqual(
-            self.page.triggered_actions,
-            [_ExternalPage.WebAction.Stop],
-        )
+        self.assertEqual(self.page.triggered_actions, [])
         self.assertEqual(self.page.delete_later_calls, 1)
 
     def test_invalid_url_does_not_consume_the_valid_handoff(self):
@@ -105,10 +99,7 @@ class ExternalLinkLifecycleTests(unittest.TestCase):
         invalid_open.assert_not_called()
         valid_open.assert_called_once()
         self.assertTrue(self.page.property("externalUrlOpened"))
-        self.assertEqual(
-            self.page.triggered_actions,
-            [_ExternalPage.WebAction.Stop],
-        )
+        self.assertEqual(self.page.triggered_actions, [])
         self.assertEqual(self.page.delete_later_calls, 1)
 
 
@@ -204,7 +195,7 @@ class PopupRoutingTests(unittest.TestCase):
         self.assertFalse(redirect_route)
         open_url.assert_called_once()
         self.assertEqual(host.internal_pages, [])
-        self.assertEqual(page.triggered_actions, [_ExternalPage.WebAction.Stop])
+        self.assertEqual(page.triggered_actions, [])
         self.assertEqual(page.delete_later_calls, 1)
 
     def test_about_blank_waits_for_the_meaningful_url(self):

--- a/zapzap/__init__.py
+++ b/zapzap/__init__.py
@@ -1,6 +1,6 @@
 from PyQt6.QtCore import QFileInfo, QUrl
 
-__version__ = '7.4.3'
+__version__ = '7.4.4'
 __appname__ = 'ZapZap'
 __comment__ = 'WhatsApp Messenger for linux'
 __domain__ = 'com.rtosta'

--- a/zapzap/features/browser/web/page_controller.py
+++ b/zapzap/features/browser/web/page_controller.py
@@ -107,9 +107,9 @@ class PageController(QWebEnginePage):
                     popup_was_closed = self._popup_host.close_popup_page(page)
                 if not popup_was_closed:
                     # A página existe apenas para receber a URL solicitada por
-                    # createWindow(). Sem o descarte explícito, ela continua
-                    # carregando o site externo e retém seu renderizador.
-                    page.triggerAction(QWebEnginePage.WebAction.Stop)
+                    # createWindow(). A navegação será recusada pelo callback;
+                    # deleteLater() evita destruir ou parar o WebEngine de
+                    # forma reentrante enquanto ele processa a solicitação.
                     page.deleteLater()
         return True
 


### PR DESCRIPTION
## Summary

- avoid calling `QWebEnginePage.WebAction.Stop` synchronously while Qt WebEngine is processing `acceptNavigationRequest`
- keep rejecting the external navigation and dispose the transient page with `deleteLater()`
- update the external-link lifecycle regression tests and start the 7.4.4 development changelog cycle

## Cause

Clicking an external link from a conversation can terminate ZapZap with `SIGTRAP`. The native stack shows `navigationRequested` entering the Python navigation callback, which then calls `WebContentsAdapter::stop()` before returning. Qt WebEngine/Chromium traps during that reentrant stop.

The navigation is already rejected when `_route_main_frame_url()` returns `False`, so an explicit synchronous `Stop` is unnecessary. `deleteLater()` retains the existing page cleanup without mutating WebEngine during its navigation callback.

## Tests

- `PYTHONPATH=. python tests/test_external_link_lifecycle.py -v` (16 passed)
- `QT_QPA_PLATFORM=offscreen python -m unittest discover -s tests -q` (515 passed)
- `python tests/check_unused_code.py --packages-only`
- `python tests/test_documentation_structure.py -v` (8 passed)
- `python -m compileall -q zapzap tests tools run.py`
- `git diff --check`
