### PR TITLE
fix(browser): defer popup disposal out of the navigation callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ This mandatory record starts after version 7.4.1. The 7.4.1 entry below is the
 historical baseline; older release summaries remain available in the GitHub
 releases and the AppStream metadata.
 
+## [7.4.5] - In development
+
+### Fixed
+
+- Prevented links opened from an internal WhatsApp popup, such as a call
+  window, from crashing Qt WebEngine by deferring the popup disposal until
+  after its navigation request has been processed. Closing the window from
+  inside the navigation callback hid its view and made Chromium discard the
+  web contents of the navigation still in flight.
+- Prevented a popup whose internal window cannot be created during shutdown
+  from stopping its page inside the same navigation callback.
+
+### Changed
+
+- Extended the internal popup and external link regression tests to cover the
+  deferred disposal and the shutdown path that still stopped a page
+  reentrantly.
+
 ## [7.4.4] - 2026-09-01
 
 ### Added
@@ -128,6 +146,7 @@ releases and the AppStream metadata.
 - Improved reliability when ZapZap is closed by the operating system.
 - Included performance improvements.
 
+[7.4.5]: https://github.com/rafatosta/zapzap/compare/7.4.4...HEAD
 [7.4.4]: https://github.com/rafatosta/zapzap/compare/7.4.3...7.4.4
 [7.4.3]: https://github.com/rafatosta/zapzap/compare/7.4.2...7.4.3
 [7.4.2]: https://github.com/rafatosta/zapzap/compare/7.4.1...7.4.2

--- a/tests/test_external_link_lifecycle.py
+++ b/tests/test_external_link_lifecycle.py
@@ -39,20 +39,47 @@ class _ExternalPage:
         self.delete_later_calls += 1
 
 
+class _DeferredTimer:
+    """Capture QTimer.singleShot callbacks so tests can run them explicitly.
+
+    Disposal must stay out of acceptNavigationRequest, so the tests assert both
+    that nothing happens synchronously and what happens once the event loop
+    turns.
+    """
+
+    def __init__(self):
+        self.pending = []
+
+    def singleShot(self, interval, callback):
+        self.pending.append((interval, callback))
+
+    def run_pending(self):
+        pending, self.pending = self.pending, []
+        for _, callback in pending:
+            callback()
+
+
 class ExternalLinkLifecycleTests(unittest.TestCase):
     def setUp(self):
         self.page = _ExternalPage()
+        self.timer = _DeferredTimer()
         self.controller = Mock()
         self.controller._popup_host = None
         self.controller.normalize_url.side_effect = lambda url: url
+        self.controller._dispose_external_page.side_effect = (
+            lambda page: PageController._dispose_external_page(
+                self.controller, page
+            )
+        )
 
-    def _open(self, url):
+    def _open(self, url, run_deferred=True):
         with (
             patch.object(
                 page_controller_module,
                 "QWebEnginePage",
                 _ExternalPage,
             ),
+            patch.object(page_controller_module, "QTimer", self.timer),
             patch.object(
                 page_controller_module.QDesktopServices,
                 "openUrl",
@@ -64,6 +91,8 @@ class ExternalLinkLifecycleTests(unittest.TestCase):
                 QUrl(url),
                 self.page,
             )
+            if run_deferred:
+                self.timer.run_pending()
             return open_url, opened
 
     def test_external_page_is_deleted_without_reentrant_stop_after_handoff(self):
@@ -102,12 +131,30 @@ class ExternalLinkLifecycleTests(unittest.TestCase):
         self.assertEqual(self.page.triggered_actions, [])
         self.assertEqual(self.page.delete_later_calls, 1)
 
+    def test_disposal_is_deferred_out_of_the_navigation_callback(self):
+        open_url, opened = self._open(
+            "https://example.com/path", run_deferred=False
+        )
+
+        # The handoff happens immediately, the disposal does not: touching the
+        # page or its window here would be reentrant inside Qt WebEngine.
+        self.assertTrue(opened)
+        open_url.assert_called_once()
+        self.assertEqual(self.page.triggered_actions, [])
+        self.assertEqual(self.page.delete_later_calls, 0)
+        self.assertEqual([interval for interval, _ in self.timer.pending], [0])
+
+        self.timer.run_pending()
+
+        self.assertEqual(self.page.delete_later_calls, 1)
+
 
 class _PopupHost:
     def __init__(self):
         self.internal_pages = []
         self.closed_pages = []
         self.popup = object()
+        self.registered_page = None
 
     def open_internal_popup(self, page):
         self.internal_pages.append(page)
@@ -115,12 +162,13 @@ class _PopupHost:
 
     def close_popup_page(self, page):
         self.closed_pages.append(page)
-        return False
+        return page is self.registered_page
 
 
 class _RoutingPage(_ExternalPage):
     _route_main_frame_url = PopupRoutingPage._route_main_frame_url
     _expire_pending_popup = PopupRoutingPage._expire_pending_popup
+    _dispose_external_page = PageController._dispose_external_page
     ROUTING_TIMEOUT_MS = PopupRoutingPage.ROUTING_TIMEOUT_MS
 
     def __init__(self, popup_host):
@@ -175,9 +223,11 @@ class PopupRoutingTests(unittest.TestCase):
     def test_external_url_opens_once_and_leaves_no_internal_popup(self):
         host = _PopupHost()
         page = _RoutingPage(host)
+        timer = _DeferredTimer()
 
         with (
             patch.object(page_controller_module, "QWebEnginePage", _ExternalPage),
+            patch.object(page_controller_module, "QTimer", timer),
             patch.object(
                 page_controller_module.QDesktopServices,
                 "openUrl",
@@ -190,11 +240,53 @@ class PopupRoutingTests(unittest.TestCase):
             redirect_route = page._route_main_frame_url(
                 QUrl("https://example.com/redirect")
             )
+            timer.run_pending()
 
         self.assertFalse(first_route)
         self.assertFalse(redirect_route)
         open_url.assert_called_once()
         self.assertEqual(host.internal_pages, [])
+        self.assertEqual(page.triggered_actions, [])
+        self.assertEqual(page.delete_later_calls, 1)
+
+    def test_registered_popup_window_is_closed_after_the_callback_returns(self):
+        host = _PopupHost()
+        page = _RoutingPage(host)
+        host.registered_page = page
+        timer = _DeferredTimer()
+
+        with (
+            patch.object(page_controller_module, "QWebEnginePage", _ExternalPage),
+            patch.object(page_controller_module, "QTimer", timer),
+            patch.object(
+                page_controller_module.QDesktopServices,
+                "openUrl",
+                return_value=True,
+            ) as open_url,
+        ):
+            route = page._route_main_frame_url(QUrl("https://example.com/first"))
+
+            # Closing the window hides its QWebEngineView, and Qt WebEngine
+            # discards the WebContents of the navigation still in flight.
+            self.assertEqual(host.closed_pages, [])
+
+            timer.run_pending()
+
+        self.assertFalse(route)
+        open_url.assert_called_once()
+        self.assertEqual(host.closed_pages, [page])
+        # The host owns the window, so the page is disposed with it.
+        self.assertEqual(page.triggered_actions, [])
+        self.assertEqual(page.delete_later_calls, 0)
+
+    def test_unavailable_internal_popup_is_deleted_without_a_stop(self):
+        host = _PopupHost()
+        host.open_internal_popup = lambda page: None
+        page = _RoutingPage(host)
+
+        route = page._route_main_frame_url(QUrl("https://web.whatsapp.com/call"))
+
+        self.assertFalse(route)
         self.assertEqual(page.triggered_actions, [])
         self.assertEqual(page.delete_later_calls, 1)
 

--- a/zapzap/__init__.py
+++ b/zapzap/__init__.py
@@ -1,6 +1,6 @@
 from PyQt6.QtCore import QFileInfo, QUrl
 
-__version__ = '7.4.4'
+__version__ = '7.4.5'
 __appname__ = 'ZapZap'
 __comment__ = 'WhatsApp Messenger for linux'
 __domain__ = 'com.rtosta'

--- a/zapzap/features/browser/web/page_controller.py
+++ b/zapzap/features/browser/web/page_controller.py
@@ -102,16 +102,28 @@ class PageController(QWebEnginePage):
             QDesktopServices.openUrl(QUrl(normalized_url))
         finally:
             if isinstance(page, QWebEnginePage):
-                popup_was_closed = False
-                if self._popup_host is not None:
-                    popup_was_closed = self._popup_host.close_popup_page(page)
-                if not popup_was_closed:
-                    # A página existe apenas para receber a URL solicitada por
-                    # createWindow(). A navegação será recusada pelo callback;
-                    # deleteLater() evita destruir ou parar o WebEngine de
-                    # forma reentrante enquanto ele processa a solicitação.
-                    page.deleteLater()
+                # Este descarte corre dentro de acceptNavigationRequest. Fechar
+                # a janela do pop-up esconde a QWebEngineView, e o Chromium
+                # descarta o WebContents durante a navegação em curso, o que é
+                # reentrante e aborta o processo. Adiar um ciclo do laço de
+                # eventos mantém o descarte fora do callback de navegação.
+                QTimer.singleShot(0, lambda: self._dispose_external_page(page))
         return True
+
+    def _dispose_external_page(self, page):
+        """Close or delete a handed-off page, outside the navigation callback."""
+
+        try:
+            popup_was_closed = False
+            if self._popup_host is not None:
+                popup_was_closed = self._popup_host.close_popup_page(page)
+            if not popup_was_closed:
+                # A página existe apenas para receber a URL solicitada por
+                # createWindow(); nada mais a mantém viva.
+                page.deleteLater()
+        except RuntimeError:
+            # A página ou a janela já foi destruída pelo Qt nesse intervalo.
+            pass
 
     def normalize_url(self, url: str) -> str:
         """Normaliza a URL removendo parâmetros redundantes."""
@@ -418,7 +430,8 @@ class PopupRoutingPage(PageController):
                     return False
                 popup = self._popup_host.open_internal_popup(self)
                 if popup is None:
-                    self.triggerAction(QWebEnginePage.WebAction.Stop)
+                    # A navegação é recusada pelo retorno False; parar a página
+                    # aqui seria reentrante durante acceptNavigationRequest.
                     self.deleteLater()
                     return False
                 self._internal_popup_opened = True


### PR DESCRIPTION
## Summary

- defer the popup disposal in `PageController._open_external_url()` to the next event-loop turn, so neither the window close nor the page deletion runs inside `acceptNavigationRequest`
- drop the sibling `WebAction.Stop` taken when an internal popup cannot be created during shutdown, which is reentrant for the same reason and unnecessary because the navigation is already refused
- extend the external-link and internal-popup regression tests to pin the deferred disposal, and open the 7.4.5 changelog cycle

Fixes #890.

## Cause

Opening a link from an internal WhatsApp popup — a call window, or a link that first lands on a WhatsApp host and then redirects off-site — terminates ZapZap with `SIGTRAP`.

`_open_external_url()` asks the host to close the popup window while Qt WebEngine is still processing `acceptNavigationRequest`. Closing it hides the `QWebEngineView`, and the hide handler makes Chromium discard the web contents of the navigation still in flight:

```
#24 QWidgetPrivate::handleClose                     <- close_from_host() -> close()
#19 QWidget::event                                  <- hide event
#10 QtWebEngineWidgets (view hide handler)
#9  QtWebEngineCore::WebContentsAdapter::setLifecycleState
#8  QtWebEngineCore::WebContentsAdapter::discard()
#0-#7 <trap inside libQt6WebEngineCore>
```

`3c20cb48` (#880) removed the reentrant `Stop` from this same method and fixed the transient page that `createWindow()` never promoted to a window — for that path `close_popup_page()` returns `False`, so no window is closed and only `deleteLater()` runs. It did not cover the promoted popup, where the host closes a real window instead, and that path still mutates WebEngine during its own navigation callback.

The disposal itself is fine; only its timing is wrong. Moving it one event-loop turn later keeps the existing behaviour — the window still closes, the page is still stopped and deleted by `InternalWebPopup.cleanup()` — without touching WebEngine while it is inside the callback. Teardown paths (`_close_internal_popups()`) are unchanged and stay synchronous, so the page is still disposed before its shared profile.

## Verification

A PyQt6 harness drives the **real** `InternalWebPopup` and `PageController._open_external_url()` through the redirect, with no WhatsApp account needed (`repro_live_popup_redirect.py`, attached to #890):

- unpatched tree: crashes at `close_from_host()`, never returning from the callback
- with this change: returns from the callback, the deferred disposal closes the window on the next turn, clean exit

The new unit tests fail against the unpatched tree and pass with the change.

## Tests

- `PYTHONPATH=. python tests/test_external_link_lifecycle.py -v` (19 passed)
- `QT_QPA_PLATFORM=offscreen python -m unittest discover -s tests -q` (518 passed)
- `python tests/check_unused_code.py --packages-only`
- `python tests/test_documentation_structure.py -v` (8 passed)
- `python -m compileall -q zapzap tests tools run.py`
- `git diff --check`

## Notes

`faulthandler.enable()` only handles `SIGSEGV`, `SIGFPE`, `SIGABRT`, `SIGBUS` and `SIGILL`, so on builds where this `CHECK` traps rather than aborts, `CrashDumpHandler` is bypassed entirely: the app vanishes and `crash-dumps/faulthandler.log` stays empty. Adding `SIGTRAP` there would surface this class of bug in user reports. Happy to send it as a separate PR if you want it.

Environment: CachyOS, KDE Plasma, Wayland, x86_64, Python 3.14, Qt 6.11.2, PyQt 6.11.0.
