### PR TITLE
feat(notifications): add native unread badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ releases and the AppStream metadata.
 
 ## [7.4.5] - In development
 
+### Added
+
+- Show native taskbar/dock unread badges on supported Qt platforms, following
+  the existing unread-counter preference. Added regression coverage and
+  documented the integration and manual validation.
+
 ### Fixed
 
 - Prevented links opened from an internal WhatsApp popup, such as a call

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -453,6 +453,12 @@ ou Wayland e dados de inicialização X11. Mudanças nessa área precisam ser
 testadas no backend afetado e, para foco/cursor/compositor, em uma sessão gráfica
 real; `offscreen` não comprova comportamento do compositor.
 
+O `SysTrayManager` também encaminha o contador agregado para
+`QApplication.setBadgeNumber()` quando a API está disponível. A mesma chave
+`system/notificationCounter` controla os contadores da bandeja e da barra de
+tarefas/dock; zero limpa o badge. A visibilidade da bandeja não condiciona o
+badge nativo. Qt decide o suporte da plataforma, sem backend D-Bus adicional.
+
 ## Tema, componentes e internacionalização
 
 `ThemeManager` mantém o tema efetivo, a `QPalette` e observadores. Controles

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -269,6 +269,15 @@ rede que possam ser sensíveis.
 - Preserve tokens de ativação Portal/Wayland e o caminho X11.
 - Teste pelo menos o backend alterado e as preferências de privacidade/som.
 
+### Contador nativo de não lidos
+
+- Preserve `system/notificationCounter` e atualize o badge junto ao contador
+  agregado em `SysTrayManager`, inclusive ao atualizar a preferência.
+- Use a API nativa Qt quando disponível; versões anteriores devem continuar
+  atualizando a bandeja normalmente.
+- Valide contagem positiva, zero, preferência desativada e bandeja oculta.
+  Confirme o resultado em uma sessão gráfica; mocks não comprovam o painel.
+
 ### Mudança visual compartilhada
 
 - Corrija primeiro o componente central e audite consumidores.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -112,6 +112,7 @@ documente o que ele protege.
 | `test_settings_radio_group.py` | divisores do grupo de rádio em `ui.components` |
 | `test_software_video_decoding.py` | presets, flags Chromium de renderização/strict proxy, persistência e ordem do bootstrap |
 | `test_spellcheck_language_picker.py` | migração, seleção múltipla transacional, pesquisa, limite, recentes, menu e perfis WebEngine |
+| `test_taskbar_badge.py` | contador nativo, zero, preferência, bandeja oculta e compatibilidade com Qt anterior |
 | `test_system_startup_settings_ui.py` | semântica de fechamento, diálogo nativo, seleção do backend gráfico, reinício e acessibilidade |
 | `test_unix_signal_shutdown.py` | ponte POSIX, restauração do estado global e `SIGTERM` real chegando a `aboutToQuit` em subprocesso isolado |
 | `test_update_checker.py` | versões, política de builds, respostas/falhas assíncronas, metadados seguros e popover acessível compartilhado entre sidebar e Sobre |
@@ -161,6 +162,7 @@ documente o que ele protege.
 - `test_software_video_decoding.py`
 - `test_spellcheck_language_picker.py`
 - `test_system_startup_settings_ui.py`
+- `test_taskbar_badge.py`
 - `test_unix_signal_shutdown.py`
 - `test_update_checker.py`
 - `test_whatsapp_app_lock.py`

--- a/tests/test_taskbar_badge.py
+++ b/tests/test_taskbar_badge.py
@@ -1,0 +1,62 @@
+"""Native unread badges follow the aggregate tray counter and its preference."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+from qt_test_case import QtTestCase
+from zapzap.features.tray.sys_tray_manager import SysTrayManager
+
+
+class TaskbarBadgeTests(QtTestCase):
+    def setUp(self):
+        self.manager = object.__new__(SysTrayManager)
+        self.manager._settings = SimpleNamespace(
+            notification_counter_enabled=True, tray_icon_enabled=False)
+        self.manager._tray = MagicMock()
+        self.manager.current_icon = object()
+        self.manager.number_notifications = 0
+        self.application = MagicMock()
+        patches = (
+            patch.object(SysTrayManager, "_instance", self.manager),
+            patch("zapzap.features.tray.sys_tray_manager.QApplication.instance",
+                  return_value=self.application),
+            patch("zapzap.features.tray.sys_tray_manager.TrayIcon.getIcon"),
+        )
+        for patcher in patches:
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def test_unread_updates_and_zero_reach_native_badge_with_tray_hidden(self):
+        for count in (3, 8, 0):
+            SysTrayManager.set_number_notifications(count)
+        self.assertEqual(self.application.setBadgeNumber.call_args_list,
+                         [call(3), call(8), call(0)])
+        self.assertEqual(self.manager.number_notifications, 0)
+        self.assertEqual(self.manager._tray.setIcon.call_count, 3)
+        self.manager._tray.show.assert_not_called()
+
+    def test_preference_refresh_clears_and_restores_current_count(self):
+        SysTrayManager.set_number_notifications(5)
+        self.manager._settings.notification_counter_enabled = False
+        SysTrayManager.refresh()
+        self.manager._settings.notification_counter_enabled = True
+        SysTrayManager.refresh()
+        self.assertEqual(self.application.setBadgeNumber.call_args_list,
+                         [call(5), call(0), call(5)])
+
+    def test_disabled_counter_keeps_new_unread_count_hidden(self):
+        self.manager._settings.notification_counter_enabled = False
+        SysTrayManager.set_number_notifications(9)
+        self.application.setBadgeNumber.assert_called_once_with(0)
+        self.assertEqual(self.manager.number_notifications, 9)
+
+    def test_older_qt_still_updates_tray_without_badge_api(self):
+        with patch("zapzap.features.tray.sys_tray_manager.QApplication.instance",
+                   return_value=SimpleNamespace()):
+            SysTrayManager.set_number_notifications(4)
+        self.manager._tray.setIcon.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/zapzap/features/tray/sys_tray_manager.py
+++ b/zapzap/features/tray/sys_tray_manager.py
@@ -112,6 +112,12 @@ class SysTrayManager:
 
         self._tray.setIcon(TrayIcon.getIcon(icon_type, number_notifications))
 
+        # Qt forwards this to the native taskbar/dock on supported platforms.
+        # Older PyQt6 releases do not expose the badge API.
+        set_badge = getattr(QApplication.instance(), "setBadgeNumber", None)
+        if set_badge is not None:
+            set_badge(number_notifications)
+
     def _open_settings(self, main_window):
         main_window.open_settings()
         main_window.restore_window()


### PR DESCRIPTION
ZapZap 7.4.4 Flatpak on Fedora KDE Plasma 6.7.4 showed the unread count in the system tray, but not on the taskbar, with the existing unread-counter preference already enabled. `SysTrayManager._set_icon()` updates the tray icon without forwarding the count to the native application badge API.

This change calls `QApplication.setBadgeNumber()` after applying the existing counter preference. Positive counts update the native badge, zero clears it, and disabling/re-enabling the preference clears/restores the current count through the existing refresh path. Hiding the tray does not suppress the native badge. Older PyQt6 versions without this API retain the existing tray behavior.

Related: #331. That report was closed after discussion of the icon setting; this PR addresses the separately reproduced taskbar behavior and does not assume the older report had the same cause.

Validation:
- All 522 unittest tests passed using the installed Flatpak Python/Qt runtime against this checkout, with the local workaround excluded from PYTHONPATH and Qt tests using isolated settings/offscreen rendering.
- Four new tests cover positive/zero counts with a hidden tray, preference toggling, unread updates while disabled, and an older Qt API.
- Package manifest check, eight documentation structure tests, compileall, and `git diff --check` passed.
- A local hook using the same Qt API was tested on the affected installation: the D-Bus badge updates and zero-clearing signal were observed, and the user confirmed the visible taskbar badge works with real unread messages. No additional Flatpak D-Bus permissions were needed. This was a local hook verification, not a rebuilt Flatpak of this branch.
- Windows, macOS, and other desktop environments were not manually tested; native badge availability is delegated to Qt.

The changelog, maintenance/architecture documentation, and test inventory are updated. The changelog entry is included under the existing 7.4.5 development section.
