### PR TITLE
fix(notifications): log why the Freedesktop backend is unavailable instead of failing silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ releases and the AppStream metadata.
   web contents of the navigation still in flight.
 - Prevented a popup whose internal window cannot be created during shutdown
   from stopping its page inside the same navigation callback.
+- Logged why the Freedesktop notification backend is unavailable instead of
+  disabling desktop notifications silently. The three early returns of the
+  D-Bus connection setup (no session bus, `org.freedesktop.Notifications` not
+  registered, signal subscription failure), the runtime `Notify` and
+  `CloseNotification` failures, and the facade fallback to no backend now emit
+  a warning; the notification sound kept playing from the WhatsApp Web page,
+  so the missing balloons looked like a desktop problem. Added regression
+  coverage and documented the manual validation.
 
 ### Changed
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -447,6 +447,19 @@ backend Freedesktop compartilham o event loop do Qt e não dependem de
 hints preservam o mapa `a{sv}` e seus tipos de protocolo, inclusive `urgency`
 como `BYTE`.
 
+Nenhuma falha de backend pode ser silenciosa. No backend Freedesktop, a
+`DBusConnection` registra um aviso em cada saída antecipada da inicialização
+(sem bus de sessão, `org.freedesktop.Notifications` não registrado, falha ao
+assinar os sinais) e ao ficar indisponível em tempo de execução (`Notify` ou
+`CloseNotification` lançando exceção, devolvendo erro ou resposta sem id). O
+aviso de indisponibilidade é emitido apenas na transição disponível para
+indisponível, para que falhas repetidas não inundem o log; a reconexão
+preguiçosa em `notify()` continua tentando reinicializar. Quando nenhum backend
+resta, `NotificationService` também avisa antes de desabilitar as notificações
+da sessão. O som da notificação vem do áudio da página do WhatsApp Web, não do
+backend, então sem esses avisos a ausência de balões parecia um problema do
+desktop.
+
 Fechamento de uma notificação WebEngine e encerramento do app devem retirar a
 notificação nativa de forma idempotente. A ativação pode carregar tokens Portal
 ou Wayland e dados de inicialização X11. Mudanças nessa área precisam ser

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -90,6 +90,7 @@ documente o que ele protege.
 | `test_documentation_structure.py` | camadas de UI, ciclo numérico versionado do changelog e sincronização entre árvore, inventários técnicos, convenção de commits e guia para agentes |
 | `test_donations_page.py` | URLs HTTPS oficiais, fallback externo, cartões responsivos/acessíveis, troca imediata de idioma e rota única pela sidebar, Configurações e Sobre |
 | `test_external_link_lifecycle.py` | classificação interna/externa de pop-ups, profile compartilhado, entrega única ao navegador e cleanup no fechamento/shutdown |
+| `test_freedesktop_notification_backend.py` | avisos nas saídas antecipadas da inicialização D-Bus, falhas de `Notify`/`CloseNotification`, aviso único na transição para indisponível e fachada sem backend |
 | `test_gpu_environment.py` | detecção multi-GPU, conectores e seleção de render node |
 | `test_grid_thumbnail_cache.py` | limite físico/DPR, reutilização, fallback, seleção e ciclo de vida das miniaturas da grade |
 | `test_http_cache_size.py` | cache em MiB, tipos de cache, política de cookies, memória JavaScript, autocura persistida e fallbacks de perfil sem WebEngine real |
@@ -139,6 +140,7 @@ documente o que ele protege.
 - `test_documentation_structure.py`
 - `test_donations_page.py`
 - `test_external_link_lifecycle.py`
+- `test_freedesktop_notification_backend.py`
 - `test_gpu_environment.py`
 - `test_grid_thumbnail_cache.py`
 - `test_http_cache_size.py`
@@ -270,6 +272,31 @@ durante a execução.
 Se o Chromium falhar com `sandbox_host_linux.cc ... Operation not permitted`,
 repita fora do sandbox e registre a limitação; não considere esse cenário como
 validação do spellchecker em runtime.
+
+## Validação manual do backend Freedesktop indisponível
+
+Use um perfil XDG descartável. O objetivo é confirmar que a ausência de balões
+deixa rastro no log em vez de parecer um problema do desktop; o som continua
+vindo da página do WhatsApp Web e não prova nada sobre o backend.
+
+### Sem bus de sessão
+
+1. Fora do Flatpak, inicie o ZapZap com `DBUS_SESSION_BUS_ADDRESS` apontando
+   para um socket inexistente, por exemplo `unix:path=/nonexistent`.
+2. Confirme no log um aviso do backend Freedesktop dizendo que não há conexão
+   com o bus de sessão e um aviso de `NotificationService` dizendo que as
+   notificações foram desabilitadas para a sessão.
+3. Confirme que o app continua utilizável e que nenhuma outra exceção aparece.
+
+### Daemon reiniciado durante a sessão
+
+1. Em uma sessão gráfica real, com o ZapZap aberto e conectado, encerre o
+   daemon de notificações do desktop (por exemplo, o processo que possui
+   `org.freedesktop.Notifications` no bus de sessão).
+2. Provoque uma notificação e confirme um único aviso de indisponibilidade no
+   log, sem repetição a cada nova mensagem.
+3. Restaure o daemon, provoque outra notificação e confirme que o balão volta a
+   aparecer sem reiniciar o ZapZap.
 
 ## Verificações estáticas
 

--- a/tests/test_freedesktop_notification_backend.py
+++ b/tests/test_freedesktop_notification_backend.py
@@ -1,0 +1,195 @@
+"""Regression tests for the Freedesktop notification backend failure logging."""
+
+from unittest.mock import MagicMock, patch
+
+from PyQt6.QtDBus import QDBusMessage
+
+from qt_test_case import QtTestCase
+from zapzap.features.notifications import (
+    freedesktop_notification_backend as backend_module,
+)
+from zapzap.features.notifications.freedesktop_notification_backend import (
+    DBusConnection,
+    FreedesktopNotificationBackend,
+)
+from zapzap.features.notifications import notification_service
+
+
+BACKEND_LOGGER = backend_module.__name__
+SERVICE_LOGGER = notification_service.__name__
+
+
+class FakeReply:
+    def __init__(self, message_type, arguments=(7,)):
+        self._message_type = message_type
+        self._arguments = list(arguments)
+
+    def type(self):
+        return self._message_type
+
+    def errorMessage(self):
+        return "daemon error"
+
+    def arguments(self):
+        return self._arguments
+
+
+class FakeInterface:
+    def __init__(self, valid=True, reply=None, error=None):
+        self._valid = valid
+        self._reply = reply or FakeReply(QDBusMessage.MessageType.ReplyMessage)
+        self._error = error
+        self.calls = []
+
+    def isValid(self):
+        return self._valid
+
+    def call(self, method, *args):
+        self.calls.append((method, *args))
+        if self._error is not None:
+            raise self._error
+        return self._reply
+
+
+class FakeNotification:
+    def __init__(self):
+        self.id = 0
+        self.icon = ""
+        self.title = "title"
+        self.body = "body"
+        self.hints = {}
+        self.timeout = 5000
+
+    def actions_list(self):
+        return []
+
+    def matches(self, _other):
+        return False
+
+
+def fake_bus(connected=True, signals=True):
+    bus = MagicMock()
+    bus.isConnected.return_value = connected
+    bus.connect.return_value = signals
+    bus.disconnect.return_value = True
+    return bus
+
+
+class FreedesktopNotificationBackendTests(QtTestCase):
+    def _connection(self, bus, interface):
+        with (
+            patch.object(
+                backend_module.QtDBusConnection, "sessionBus",
+                return_value=bus,
+            ),
+            patch.object(
+                backend_module, "QDBusInterface", return_value=interface,
+            ),
+        ):
+            return DBusConnection("zapzap-tests")
+
+    # -- startup: the three early returns of DBusConnection._init() --------
+
+    def test_missing_session_bus_is_logged(self):
+        with self.assertLogs(BACKEND_LOGGER, level="WARNING") as logs:
+            connection = self._connection(
+                fake_bus(connected=False), FakeInterface()
+            )
+        self.assertFalse(connection.available)
+        self.assertIn("no session D-Bus connection", logs.output[0])
+
+    def test_unregistered_service_is_logged(self):
+        with self.assertLogs(BACKEND_LOGGER, level="WARNING") as logs:
+            connection = self._connection(
+                fake_bus(), FakeInterface(valid=False)
+            )
+        self.assertFalse(connection.available)
+        self.assertIn("is not registered on the session bus", logs.output[0])
+        self.assertIn(DBusConnection.SERVICE, logs.output[0])
+
+    def test_signal_subscription_failure_is_logged(self):
+        with self.assertLogs(BACKEND_LOGGER, level="WARNING") as logs:
+            connection = self._connection(
+                fake_bus(signals=False), FakeInterface()
+            )
+        self.assertFalse(connection.available)
+        self.assertIn("could not subscribe", logs.output[0])
+
+    def test_healthy_startup_logs_nothing(self):
+        with self.assertNoLogs(BACKEND_LOGGER, level="WARNING"):
+            connection = self._connection(fake_bus(), FakeInterface())
+        self.assertTrue(connection.available)
+
+    # -- runtime: the Notify call paths that call _mark_unavailable() ------
+
+    def _healthy_connection(self, **interface_kwargs):
+        interface = FakeInterface(**interface_kwargs)
+        connection = self._connection(fake_bus(), interface)
+        self.assertTrue(connection.available)
+        return connection
+
+    def test_notify_exception_disables_backend_with_log(self):
+        connection = self._healthy_connection(error=RuntimeError("boom"))
+        with self.assertLogs(BACKEND_LOGGER, level="WARNING") as logs:
+            self.assertFalse(connection.notify(FakeNotification()))
+        self.assertFalse(connection.available)
+        self.assertIn("raised an exception", logs.output[0])
+        self.assertIn("RuntimeError: boom", logs.output[0])
+
+    def test_notify_error_reply_disables_backend_with_log(self):
+        connection = self._healthy_connection(
+            reply=FakeReply(QDBusMessage.MessageType.ErrorMessage)
+        )
+        with self.assertLogs(BACKEND_LOGGER, level="WARNING") as logs:
+            self.assertFalse(connection.notify(FakeNotification()))
+        self.assertFalse(connection.available)
+        self.assertIn("returned an error (daemon error)", logs.output[0])
+
+    def test_notify_reply_without_id_disables_backend_with_log(self):
+        connection = self._healthy_connection(
+            reply=FakeReply(
+                QDBusMessage.MessageType.ReplyMessage, arguments=()
+            )
+        )
+        with self.assertLogs(BACKEND_LOGGER, level="WARNING") as logs:
+            self.assertFalse(connection.notify(FakeNotification()))
+        self.assertFalse(connection.available)
+        self.assertIn("returned no notification id", logs.output[0])
+
+    def test_unavailable_transition_is_logged_once(self):
+        connection = self._healthy_connection()
+        with self.assertLogs(BACKEND_LOGGER, level="WARNING") as logs:
+            connection._mark_unavailable("first failure")
+        self.assertEqual(len(logs.output), 1)
+        with self.assertNoLogs(BACKEND_LOGGER, level="WARNING"):
+            connection._mark_unavailable("second failure")
+        self.assertFalse(connection.available)
+
+    # -- facade: NotificationService._select_backend() --------------------
+
+    def test_service_logs_when_no_backend_is_available(self):
+        unavailable = MagicMock(spec=FreedesktopNotificationBackend)
+        unavailable.available.return_value = False
+        notification_service.NotificationService._backend = None
+        self.addCleanup(
+            setattr, notification_service.NotificationService, "_backend", None
+        )
+        with (
+            patch("zapzap.core.platform.IS_WINDOWS", False),
+            patch("zapzap.core.platform.IS_MAC", False),
+            patch.object(notification_service, "is_flatpak", return_value=False),
+            patch.object(
+                notification_service, "FreedesktopNotificationBackend",
+                return_value=unavailable,
+            ),
+            self.assertLogs(SERVICE_LOGGER, level="WARNING") as logs,
+        ):
+            service = notification_service.NotificationService()
+        self.assertIsNone(service.backend)
+        self.assertIn("No notification backend is available", logs.output[0])
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/zapzap/features/notifications/freedesktop_notification_backend.py
+++ b/zapzap/features/notifications/freedesktop_notification_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import logging
 import os
 from collections import OrderedDict
 
@@ -29,6 +30,8 @@ from zapzap.assets.icons.tray_icon import TrayIcon
 from zapzap.core.config.settings_manager import SettingsManager
 from zapzap.features.notifications.window_activation import activate_window
 from zapzap import __appname__
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from zapzap.features.browser.web.web_view import WebView
@@ -141,6 +144,10 @@ class DBusConnection(QObject):
         self.available = False
 
         if not self.bus.isConnected():
+            logger.warning(
+                "Freedesktop notifications unavailable: "
+                "there is no session D-Bus connection."
+            )
             return
 
         interface = QDBusInterface(
@@ -150,9 +157,19 @@ class DBusConnection(QObject):
             self.bus,
         )
         if not interface.isValid():
+            logger.warning(
+                "Freedesktop notifications unavailable: %s is not registered "
+                "on the session bus.",
+                self.SERVICE,
+            )
             return
 
         if not self._signals_connected and not self._connect_signals():
+            logger.warning(
+                "Freedesktop notifications unavailable: could not subscribe to "
+                "the %s signals.",
+                self.SERVICE,
+            )
             return
 
         self.interface = interface
@@ -185,7 +202,18 @@ class DBusConnection(QObject):
         self._signals_connected = True
         return True
 
-    def _mark_unavailable(self):
+    def _mark_unavailable(
+        self,
+        reason: str = "the notification service became unavailable",
+        *,
+        exc_info: bool = False,
+    ):
+        if self.available:
+            logger.warning(
+                "Freedesktop notifications disabled: %s",
+                reason,
+                exc_info=exc_info,
+            )
         self.available = False
         self.interface = None
 
@@ -251,16 +279,20 @@ class DBusConnection(QObject):
                 notification.timeout,
             )
         except Exception:
-            self._mark_unavailable()
+            self._mark_unavailable(
+                "the Notify call raised an exception", exc_info=True
+            )
             return False
 
         if reply.type() == QDBusMessage.MessageType.ErrorMessage:
-            self._mark_unavailable()
+            self._mark_unavailable(
+                f"the Notify call returned an error ({reply.errorMessage()})"
+            )
             return False
 
         arguments = reply.arguments()
         if not arguments:
-            self._mark_unavailable()
+            self._mark_unavailable("the Notify call returned no notification id")
             return False
 
         for old in list(self._notifications.values()):
@@ -279,9 +311,14 @@ class DBusConnection(QObject):
                     self._dbus_uint(notification.id),
                 )
                 if reply.type() == QDBusMessage.MessageType.ErrorMessage:
-                    self._mark_unavailable()
+                    self._mark_unavailable(
+                        "the CloseNotification call returned an error "
+                        f"({reply.errorMessage()})"
+                    )
             except Exception:
-                self._mark_unavailable()
+                self._mark_unavailable(
+                    "the CloseNotification call raised an exception", exc_info=True
+                )
 
     # ------------------------------------------------------------------
     # DBus callbacks

--- a/zapzap/features/notifications/notification_service.py
+++ b/zapzap/features/notifications/notification_service.py
@@ -65,7 +65,14 @@ class NotificationService:
             return PortalNotificationBackend()
 
         backend = FreedesktopNotificationBackend()
-        return backend if backend.available() else None
+        if backend.available():
+            return backend
+
+        logger.warning(
+            "No notification backend is available; "
+            "desktop notifications are disabled for this session."
+        )
+        return None
 
     @classmethod
     def shutdown(cls):


### PR DESCRIPTION
## Problem

When the Freedesktop notification backend cannot be used, ZapZap disables desktop notifications without emitting a single log line. The user still hears the notification sound, because that comes from the WhatsApp Web page audio and not from the backend, so the app looks like it is working. There is no way to tell that notifications are off, or why.

Four paths fail silently today:

| Location | Condition |
|---|---|
| `DBusConnection._init()` | `bus.isConnected()` is false |
| `DBusConnection._init()` | `QDBusInterface.isValid()` is false |
| `DBusConnection._init()` | `_connect_signals()` fails |
| `DBusConnection._mark_unavailable()` | reached from 5 call sites, two of them bare `except Exception` blocks in `notify()` and `close_notification()` |

`freedesktop_notification_backend.py` has no logger at all, and `NotificationService._select_backend()` returns `None` without a message even though that module already defines `logger`.

## Why this matters

A real case on Fedora 44 with KDE: the 7.0 AppImage shipped an incomplete `dbus` package. The directory existed, so `import dbus` succeeded, but `dbus.mainloop.glib` was missing. The `try/except` swallowed it, `available()` returned false, and notifications were silently disabled. Because the sound kept playing, it looked like a desktop or KDE problem, and pinning it down required reading the source and attaching a remote debugger. One warning line would have made it obvious in seconds.

That particular bug is already gone: `97f9eda6` ("Move Freedesktop notifications to QtDBus") dropped the python-dbus dependency, so thanks for that. The silent failure mode itself is still present, and it now covers different causes: no session bus, service not registered, signal subscription failure, or runtime errors from the `Notify` call.

## Change

Logging only, no behaviour change.

- `freedesktop_notification_backend.py`: adds a module logger, one warning per failure reason in `_init()`, and `_mark_unavailable(reason, *, exc_info=False)` that logs once on the available to unavailable transition, so repeated failures do not spam the log. The two `except Exception` blocks pass `exc_info=True`.
- `notification_service.py`: `_select_backend()` logs a warning before returning `None`.

## Before and after

Running with `DBUS_SESSION_BUS_ADDRESS` pointing at a nonexistent socket.

Before, on `main`:

```
backend = None
```

After:

```
WARNING zapzap...freedesktop_notification_backend: Freedesktop notifications unavailable: there is no session D-Bus connection.
WARNING zapzap...notification_service: No notification backend is available; desktop notifications are disabled for this session.
backend = None
```

## Documentation and tests (added after review)

- `CHANGELOG.md`: entry under `[7.4.5] - In development`, `### Fixed`.
- `docs/architecture.md`: the failure-logging contract of the Freedesktop backend and the facade, in the "Notificações e ativação" section.
- `tests/test_freedesktop_notification_backend.py`: 9 tests with fakes at the QtDBus boundary. They cover the three early returns of `_init()`, the `Notify` exception / error reply / empty reply paths, the single warning on the available to unavailable transition, a healthy startup that must log nothing, and the facade warning when no backend is left. 8 of the 9 fail on `main` without the fix, as `docs/testing.md` asks for regression tests.
- `docs/testing.md`: inventory table and list rows, plus a manual validation script (missing session bus, and daemon restarted mid-session).
- `_mark_unavailable()` now takes an optional `reason` with a default, so the existing `test_notification_window_activation` caller that invokes it without arguments keeps working.

## Testing

Everything listed in `AGENTS.md`, on this branch rebased onto `main`:

- `python -m unittest discover -s tests -q`: 531 tests. The new module passes (9/9). 17 tests fail, all pre-existing on a clean `upstream/main` checkout in the same environment and all in settings/UI modules (`test_network_privacy_settings_ui`, `test_performance_experimental_settings_ui`, `test_system_startup_settings_ui`, and single cases in a few others); none of them touch notifications, and this branch adds no failure that `main` does not already have here.
- `python tests/check_unused_code.py --packages-only`: no mismatches.
- `python tests/test_documentation_structure.py -v`: 8/8.
- `python -m compileall -q zapzap tests tools run.py`: clean.
- `git diff --check`: clean.

Environment: Fedora 44, KDE Plasma 6, Python 3.14, PyQt6 6.11, `QT_QPA_PLATFORM=offscreen`.

## Possible follow-up, not in this PR

`PortalNotificationBackend` has no `available()`, so it cannot serve as a fallback when the Freedesktop backend is down. Adding one and falling back would keep notifications working in more environments. I left it out because the comment in `portal_notification_backend.py` about QtDBus not being able to marshal the required nested structure suggests the avatar may not survive that path, and that deserves its own testing.

(Generated with Claude Code Opus 5.0)

